### PR TITLE
Introduce a sanity github action check

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -1,0 +1,20 @@
+name: sanity
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    paths:
+      - '**'
+
+jobs:
+  sanity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '~1.16'
+      - name: Run verification checks
+        run: make verify

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # Dependency directories
 vendor/
+bin/

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ tidy: ## Update dependencies
 	$(Q)go mod tidy -v
 
 vendor: tidy ## Update vendor directory
-	$(Q)go mod vendor 
+	$(Q)go mod vendor
 
 generate: controller-gen  ## Generate code
 	$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths=./...
@@ -49,12 +49,11 @@ test: test-unit ## Run the tests
 test-unit: ## Run the unit tests
 	$(Q)go test -count=1 -short ${PKGS}
 
-verify: manifests generate
+verify: tidy format manifests generate
 	git diff --exit-code
 
 # Utilities.
 .PHONY: controller-gen
 
-controller-gen: vendor ## Find or download controller-gen 
+controller-gen: vendor ## Find or download controller-gen
 CONTROLLER_GEN=$(Q)go run -mod=vendor ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
-


### PR DESCRIPTION
Introduce the .github/workflows directory and add a action that ensures
that the codegen (manifests/APIs) are up-to-date and the package
formatting (go fmt/goimports) don't produce a diff.

Update the Makefile's format target and also run the goimports command
against the set of Go packages