### PR TITLE
Makefile,manifests: Add skeleton of default rukpak resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ test-unit: ## Run the unit tests
 verify: tidy generate format
 	git diff --exit-code
 
+install: generate
+	kubectl apply -f manifests
+	kubectl apply -f provisioner/k8s/manifests
+
 # Binary builds
 GO_BUILD := $(Q)go build
 

--- a/provisioner/k8s/manifests/namespace.yaml
+++ b/provisioner/k8s/manifests/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8s-provisioner

--- a/provisioner/k8s/manifests/provisionerclass.yaml
+++ b/provisioner/k8s/manifests/provisionerclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: core.rukpak.io/v1alpha1
+kind: ProvisionerClass
+metadata:
+  name: default
+spec:
+  provisioner: rukpak.io/k8s

--- a/provisioner/k8s/manifests/rbac.yaml
+++ b/provisioner/k8s/manifests/rbac.yaml
@@ -1,0 +1,59 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: k8s-provisioner-admin
+  namespace: k8s-provisioner
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "*"
+  verbs:
+  - "*"
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8s-provisioner-admin
+rules:
+- apiGroups:
+  - "*"
+  resources:
+  - "*"
+  verbs:
+  - "*"
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-provisioner-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8s-provisioner-admin
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: k8s-provisioner-admin
+  namespace: k8s-provisioner
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: k8s-provisioner-admin
+  namespace: k8s-provisioner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: k8s-provisioner-admin
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: k8s-provisioner-admin
+  namespace: k8s-provisioner

--- a/provisioner/k8s/manifests/serviceaccount.yaml
+++ b/provisioner/k8s/manifests/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-provisioner-admin
+  namespace: k8s-provisioner


### PR DESCRIPTION
Update the Makefile and add an `install` target that creates the
rukpak-specific resources.

Update the manifests root directory and add manifests for a `rukpak`
namespace and the requisite RBAC.