### PR TITLE
Dockerfile: Optimize image layers to enable better caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,22 @@
 FROM golang:1.17-buster AS builder
 
-WORKDIR /build
-COPY . .
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
 
+COPY Makefile Makefile
+COPY api api
+COPY provisioner provisioner
 RUN make build
 
 FROM gcr.io/distroless/static:debug
 
 WORKDIR /
-COPY --from=builder /build/bin/k8s .
-
+COPY --from=builder /workspace/bin/k8s .
 EXPOSE 8080
 
 ENTRYPOINT ["k8s"]


### PR DESCRIPTION
Update the root Dockerfile and replace the generic `COPY . .` command
with only the files and directories needed to create the provisioner
binar(ies). This should help speed up builds as we're not invalidating
the image layer when we modify a file that doesn't affect the actual
build.

Also update the Dockerfile and ensure we're downloading Go
modules at the beginning of the build stage to help cache dependencies
and decrease over build times over subsequent builds.

Signed-off-by: timflannagan <timflannagan@gmail.com>