### PR TITLE
kuberpak: Refactor and dependency inject the provisioner package

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"time"
 
+	olmv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -14,7 +15,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
+
+func BundleProvisionerFilter(provisionerClassName string) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		b := obj.(*olmv1alpha1.Bundle)
+		return b.Spec.ProvisionerClassName == provisionerClassName
+	})
+}
 
 func PodName(bundleName string) string {
 	return fmt.Sprintf("registryv1-unpack-bundle-%s", bundleName)

--- a/provisioner/registryv1/controllers/bundle_controller.go
+++ b/provisioner/registryv1/controllers/bundle_controller.go
@@ -40,13 +40,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/yaml"
 
 	olmv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	"github.com/operator-framework/rukpak/internal/storage"
 	"github.com/operator-framework/rukpak/internal/updater"
 	"github.com/operator-framework/rukpak/internal/util"
+)
+
+const (
+	registryV1ProvisionerID = "kuberpak.io/registry+v1"
 )
 
 // BundleReconciler reconciles a Bundle object
@@ -408,17 +411,10 @@ func getObjects(bundleFS fs.FS) ([]client.Object, error) {
 func (r *BundleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&olmv1alpha1.Bundle{}, builder.WithPredicates(
-			bundleProvisionerFilter("core.rukpak.io/registry+v1"),
+			util.BundleProvisionerFilter(registryV1ProvisionerID),
 		)).
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.Pod{}).
 		Owns(&corev1.ConfigMap{}).
 		Complete(r)
-}
-
-func bundleProvisionerFilter(provisionerClassName string) predicate.Predicate {
-	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		b := obj.(*olmv1alpha1.Bundle)
-		return b.Spec.ProvisionerClassName == provisionerClassName
-	})
 }

--- a/provisioner/registryv1/controllers/bundle_controller.go
+++ b/provisioner/registryv1/controllers/bundle_controller.go
@@ -71,10 +71,6 @@ type BundleReconciler struct {
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the Bundle object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/reconcile

--- a/provisioner/registryv1/controllers/bundleinstance_controller.go
+++ b/provisioner/registryv1/controllers/bundleinstance_controller.go
@@ -101,7 +101,7 @@ func (r *BundleInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	defer func() {
 		bi := bi.DeepCopy()
 		bi.ObjectMeta.ManagedFields = nil
-		if err := r.Status().Patch(ctx, bi, client.Apply, client.FieldOwner("core.rukpak.io/registry+v1")); err != nil {
+		if err := r.Status().Patch(ctx, bi, client.Apply, client.FieldOwner(registryV1ProvisionerID)); err != nil {
 			l.Error(err, "failed to patch status")
 		}
 	}()
@@ -424,7 +424,7 @@ func (r *BundleInstanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	//r.ActionConfigGetter = helmclient.NewActionConfigGetter(mgr.GetConfig(), mgr.GetRESTMapper(), mgr.GetLogger())
 	//r.ActionClientGetter = helmclient.NewActionClientGetter(r.ActionConfigGetter)
 	controller, err := ctrl.NewControllerManagedBy(mgr).
-		For(&olmv1alpha1.BundleInstance{}, builder.WithPredicates(bundleInstanceProvisionerFilter("core.rukpak.io/registry+v1"))).
+		For(&olmv1alpha1.BundleInstance{}, builder.WithPredicates(bundleInstanceProvisionerFilter(registryV1ProvisionerID))).
 		Watches(&source.Kind{Type: &olmv1alpha1.Bundle{}}, handler.EnqueueRequestsFromMapFunc(mapBundleToBundleInstanceHandler(mgr.GetClient(), mgr.GetLogger()))).
 		Build(r)
 	if err != nil {


### PR DESCRIPTION
Update the Bundle controller and refactor the existing methods on the BundleReconciler type by dependency injecting the needed  method types as function parameters. This PR also takes an initial stab at cleaning up the registry+v1 Bundle and BundleInstance controllers to help improve modularity and readability. 