### PR TITLE
Makefile,Dockerfile: Fix the runtime errors in the rukpak container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,5 @@ WORKDIR /
 COPY --from=builder /workspace/bin/k8s .
 EXPOSE 8080
 
-ENTRYPOINT ["k8s"]
+ENTRYPOINT ["/k8s"]
 CMD ["run"]

--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,12 @@ help: ## Show this help screen
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 # Code management
-.PHONY: lint format tidy clean generate
+.PHONY: lint tidy clean generate
 
 PKGS = $(shell go list ./...)
 
 lint: golangci-lint
 	$(Q)$(GOLANGCI_LINT) run
-
-format: ## Format the source code
-	$(Q)go fmt ./...
 
 tidy: ## Update dependencies
 	$(Q)go mod tidy
@@ -38,7 +35,7 @@ test-unit: ## Run the unit tests
 test-e2e: ginkgo ## Run the e2e tests
 	$(GINKGO) run test/e2e
 
-verify: tidy generate format ## Verify the current code generation and lint
+verify: tidy generate ## Verify the current code generation and lint
 	git diff --exit-code
 
 install: generate

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,3 @@
-# kernel-style V=1 build verbosity
-ifeq ("$(origin V)", "command line")
-  BUILD_VERBOSE = $(V)
-endif
-
-ifeq ($(BUILD_VERBOSE),1)
-  Q =
-else
-  Q = @
-endif
-
 
 .PHONY: help
 help: ## Show this help screen
@@ -38,7 +27,7 @@ generate: controller-gen ## Generate code and manifests
 	$(Q)$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths=./api/...
 
 # Static tests.
-.PHONY: test test-unit verify build bin/k8s
+.PHONY: test test-unit verify build bin/k8s bin/kuberpak
 
 test: test-unit test-e2e ## Run the tests
 
@@ -63,10 +52,10 @@ GO_BUILD := $(Q)go build
 build: bin/k8s bin/kuberpak
 
 bin/k8s:
-	$(GO_BUILD) -o $@ ./provisioner/k8s
+	CGO_ENABLED=0 go build -o $@ ./provisioner/k8s
 
 bin/kuberpak:
-	$(GO_BUILD) -o $@ ./provisioner/kuberpak
+	CGO_ENABLED=0 go build -o $@ ./provisioner/kuberpak
 
 
 ## --------------------------------------
@@ -94,3 +83,4 @@ $(GINKGO): $(TOOLS_DIR)/go.mod # Build ginkgo from tools folder.
 	cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/ginkgo github.com/onsi/ginkgo/ginkgo
 $(GOLANGCI_LINT): $(TOOLS_DIR)/go.mod # Build golangci-lint from tools folder.
 	cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/golangci-lint github.com/golangci/golangci-lint/cmd/golangci-lint
+	CGO_ENABLED=0 go build -o $@ ./provisioner/kuberpak


### PR DESCRIPTION
Update the Makefile and ensure that cgo is disabled for both the
registry+v1 and plain bundle provisioners. Update the Dockerfile to
specify an explicit path to the `k8s` executable to silence the "exec
user process caused: no such file or directory" error message when
running this container image locally.

Signed-off-by: timflannagan <timflannagan@gmail.com>