### PR TITLE
.github/workflow: Ensure we're caching the go module cache

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,19 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '~1.17'
-      - run: make build
+
+      - name: Cache the go module and build paths
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Build the provisioner binaries
+        run: make build
 
   image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update the build GHA workflow and ensure we're caching the Go module
cache between CI runs. This allows us to have quicker overall CI run
times as we avoid having to constantly populate the Go module cache when
building the provisioner binaries in CI.

Signed-off-by: timflannagan <timflannagan@gmail.com>