### PR TITLE
chore: removing provisionerclass.yaml from k8s provisioner

### DIFF
--- a/provisioner/k8s/manifests/provisionerclass.yaml
+++ b/provisioner/k8s/manifests/provisionerclass.yaml
@@ -1,6 +1,0 @@
-apiVersion: core.rukpak.io/v1alpha1
-kind: ProvisionerClass
-metadata:
-  name: default
-spec:
-  provisioner: rukpak.io/k8s


### PR DESCRIPTION
Removing this manifest as it appears to be vestigial and prevents installation of the k8s provisioner on cluster.