### PR TITLE
k8s: Avoid using OLM's cpb tool for unpacking Bundle contents

### DIFF
--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -139,20 +139,24 @@ func (s *ConfigMaps) buildObject(obj client.Object, owner client.Object) (*corev
 	gvk := obj.GetObjectKind().GroupVersionKind()
 
 	labels := map[string]string{
-		"core.rukpak.io/owner-name":       owner.GetName(),
-		"core.rukpak.io/configmap-type":   "object",
+		"core.rukpak.io/owner-name":     owner.GetName(),
+		"core.rukpak.io/configmap-type": "object",
+	}
+	annotations := map[string]string{
 		"core.rukpak.io/object-group":     gvk.Group,
 		"core.rukpak.io/object-version":   gvk.Version,
 		"core.rukpak.io/object-kind":      gvk.Kind,
 		"core.rukpak.io/object-name":      obj.GetName(),
 		"core.rukpak.io/object-namespace": obj.GetNamespace(),
 	}
+
 	immutable := true
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%sobject-%s-%s", s.NamePrefix, owner.GetName(), hash[0:8]),
-			Namespace: s.Namespace,
-			Labels:    labels,
+			Name:        fmt.Sprintf("%sobject-%s-%s", s.NamePrefix, owner.GetName(), hash[0:8]),
+			Namespace:   s.Namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Immutable: &immutable,
 		Data: map[string]string{

--- a/provisioner/k8s/controllers/bundle_controller.go
+++ b/provisioner/k8s/controllers/bundle_controller.go
@@ -47,6 +47,10 @@ import (
 	"github.com/operator-framework/rukpak/internal/util"
 )
 
+const (
+	bundleUnpackContainerName = "bundle"
+)
+
 // BundleReconciler reconciles a Bundle object
 type BundleReconciler struct {
 	client.Client
@@ -215,7 +219,7 @@ func (r *BundleReconciler) ensureUnpackPod(ctx context.Context, bundle *olmv1alp
 		if len(pod.Spec.Containers) != 1 {
 			pod.Spec.Containers = make([]corev1.Container, 1)
 		}
-		pod.Spec.Containers[0].Name = "copy-bundle"
+		pod.Spec.Containers[0].Name = bundleUnpackContainerName
 		pod.Spec.Containers[0].Image = bundle.Spec.Image
 		pod.Spec.Containers[0].ImagePullPolicy = corev1.PullAlways
 		pod.Spec.Containers[0].Command = []string{"/util/unpack", "--bundle-dir", "/manifests"}
@@ -328,7 +332,7 @@ func (r *BundleReconciler) getPodLogs(ctx context.Context, pod *corev1.Pod) ([]b
 
 func (r *BundleReconciler) getBundleImageDigest(pod *corev1.Pod) (string, error) {
 	for _, ps := range pod.Status.ContainerStatuses {
-		if ps.Name == "copy-bundle" && ps.ImageID != "" {
+		if ps.Name == bundleUnpackContainerName && ps.ImageID != "" {
 			return ps.ImageID, nil
 		}
 	}

--- a/provisioner/k8s/controllers/bundleinstance_controller.go
+++ b/provisioner/k8s/controllers/bundleinstance_controller.go
@@ -332,7 +332,7 @@ func (r *BundleInstanceReconciler) loadBundle(ctx context.Context, bi *olmv1alph
 		return nil, fmt.Errorf("load bundle objects: %w", err)
 	}
 
-	objs := make([]client.Object, len(objects))
+	objs := make([]client.Object, 0, len(objects))
 	for _, obj := range objects {
 		obj := obj
 		obj.SetLabels(util.MergeMaps(obj.GetLabels(), map[string]string{

--- a/provisioner/k8s/main.go
+++ b/provisioner/k8s/main.go
@@ -112,13 +112,12 @@ func main() {
 	}
 
 	if err = (&controllers.BundleReconciler{
-		Client:          mgr.GetClient(),
-		KubeClient:      kubeClient,
-		Scheme:          mgr.GetScheme(),
-		PodNamespace:    ns,
-		Storage:         bundleStorage,
-		UnpackImage:     "quay.io/joelanford/kuberpak-unpack:v0.1.0",
-		CopyBundleImage: "quay.io/tflannag/olm:cpb-hacks-latest",
+		Client:       mgr.GetClient(),
+		KubeClient:   kubeClient,
+		Scheme:       mgr.GetScheme(),
+		PodNamespace: ns,
+		Storage:      bundleStorage,
+		UnpackImage:  "quay.io/tflannag/unpack:latest",
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Bundle")
 		os.Exit(1)

--- a/provisioner/k8s/main.go
+++ b/provisioner/k8s/main.go
@@ -56,9 +56,11 @@ func main() {
 	var enableLeaderElection bool
 	var probeAddr string
 	var systemNamespace string
+	var unpackImage string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.StringVar(&systemNamespace, "system-namespace", "rukpak-system", "Configures the namespace that gets used to deploy system resources")
+	flag.StringVar(&systemNamespace, "system-namespace", "rukpak-system", "Configures the namespace that gets used to deploy system resources.")
+	flag.StringVar(&unpackImage, "unpack-image", "quay.io/tflannag/unpack:latest", "Configures the container image that gets used to unpack Bundle contents.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -117,7 +119,7 @@ func main() {
 		Scheme:       mgr.GetScheme(),
 		PodNamespace: ns,
 		Storage:      bundleStorage,
-		UnpackImage:  "quay.io/tflannag/unpack:latest",
+		UnpackImage:  unpackImage,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Bundle")
 		os.Exit(1)

--- a/unpack.Dockerfile
+++ b/unpack.Dockerfile
@@ -17,7 +17,12 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o unpack ./cmd/unpack/
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+#
+# Note(tflannag): Use the `debug` image tag so we have access to a shell when unpacking
+# Bundle contents. This allows us to use the `cp` shell command for copying the /unpack binary
+# to a scratch-based container image, which doesn't contain a shell environment, but contains the
+# Bundle manifests we need to extract.
+FROM gcr.io/distroless/static:debug
 WORKDIR /
 COPY --from=builder /workspace/unpack .
 USER 65532:65532


### PR DESCRIPTION
Follow-up to #69 and remove the need to use OLM's cpb tooling to copy Bundle contents from scratch-based bundle container images.