### PR TITLE
internal,provisioner: Support configuring the system namespace

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/ioutil"
 	"reflect"
 	"time"
 
@@ -15,6 +16,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
+
+// GetPodNamespace checks whether the controller is running in a Pod vs.
+// being run locally by inspecting the namespace file that gets mounted
+// automatically for Pods at runtime. If that file doesn't exist, then
+// return the @defaultNamespace namespace parameter.
+func PodNamespace(defaultNamespace string) string {
+	namespace, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return defaultNamespace
+	}
+	return string(namespace)
+}
 
 func PodName(provisionerName, bundleName string) string {
 	return fmt.Sprintf("%s-unpack-bundle-%s", provisionerName, bundleName)

--- a/provisioner/k8s/main.go
+++ b/provisioner/k8s/main.go
@@ -35,6 +35,7 @@ import (
 
 	olmv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	"github.com/operator-framework/rukpak/internal/storage"
+	"github.com/operator-framework/rukpak/internal/util"
 	"github.com/operator-framework/rukpak/provisioner/k8s/controllers"
 )
 
@@ -54,8 +55,10 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var systemNamespace string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&systemNamespace, "system-namespace", "rukpak-system", "Configures the namespace that gets used to deploy system resources")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -101,9 +104,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// TODO: derive pod namespace from the pod that this process is running in.
-	ns := "rukpak-system"
-
+	ns := util.PodNamespace(systemNamespace)
 	bundleStorage := &storage.ConfigMaps{
 		Client:     mgr.GetClient(),
 		Namespace:  ns,


### PR DESCRIPTION
Introduce a flag to the k8s provisioner binary for configuring the
namespace that's used to house system resources. Add a helper function
that checks whether the provisioner is running in a Pod vs. locally, and
defaults to the Pod's serviceaccount namespace file if present.

Signed-off-by: timflannagan <timflannagan@gmail.com>