### PR TITLE
provisioner/k8s: add owner-kind label

### DIFF
--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -114,6 +114,7 @@ func (s *ConfigMaps) Store(ctx context.Context, owner client.Object, objects []c
 func (s *ConfigMaps) getExistingConfigMaps(ctx context.Context, owner client.Object) ([]corev1.ConfigMap, error) {
 	cmList := &corev1.ConfigMapList{}
 	labels := map[string]string{
+		"core.rukpak.io/owner-kind": owner.GetObjectKind().GroupVersionKind().Kind,
 		"core.rukpak.io/owner-name": owner.GetName(),
 	}
 	if err := s.Client.List(ctx, cmList, client.MatchingLabels(labels), client.InNamespace(s.Namespace)); err != nil {
@@ -139,6 +140,7 @@ func (s *ConfigMaps) buildObject(obj client.Object, owner client.Object) (*corev
 	gvk := obj.GetObjectKind().GroupVersionKind()
 
 	labels := map[string]string{
+		"core.rukpak.io/owner-kind":     owner.GetObjectKind().GroupVersionKind().Kind,
 		"core.rukpak.io/owner-name":     owner.GetName(),
 		"core.rukpak.io/configmap-type": "object",
 	}
@@ -189,6 +191,7 @@ func (s *ConfigMaps) buildMetadata(dcms []corev1.ConfigMap, owner client.Object)
 			Namespace: s.Namespace,
 			Name:      fmt.Sprintf("%smetadata-%s", s.NamePrefix, owner.GetName()),
 			Labels: map[string]string{
+				"core.rukpak.io/owner-kind":     owner.GetObjectKind().GroupVersionKind().Kind,
 				"core.rukpak.io/owner-name":     owner.GetName(),
 				"core.rukpak.io/configmap-type": "metadata",
 			},

--- a/provisioner/k8s/controllers/bundle_controller.go
+++ b/provisioner/k8s/controllers/bundle_controller.go
@@ -201,7 +201,10 @@ func (r *BundleReconciler) ensureUnpackPod(ctx context.Context, bundle *olmv1alp
 	pod.SetNamespace(r.PodNamespace)
 
 	return util.CreateOrRecreate(ctx, r.Client, pod, func() error {
-		pod.SetLabels(map[string]string{"core.rukpak.io/owner-name": bundle.Name})
+		pod.SetLabels(map[string]string{
+			"core.rukpak.io/owner-kind": "Bundle",
+			"core.rukpak.io/owner-name": bundle.Name,
+		})
 		pod.SetOwnerReferences([]metav1.OwnerReference{*controllerRef})
 		pod.Spec.AutomountServiceAccountToken = &automountServiceAccountToken
 		pod.Spec.Volumes = []corev1.Volume{

--- a/provisioner/k8s/controllers/bundleinstance_controller.go
+++ b/provisioner/k8s/controllers/bundleinstance_controller.go
@@ -336,6 +336,7 @@ func (r *BundleInstanceReconciler) loadBundle(ctx context.Context, bi *olmv1alph
 	for _, obj := range objects {
 		obj := obj
 		obj.SetLabels(util.MergeMaps(obj.GetLabels(), map[string]string{
+			"core.rukpak.io/owner-kind": "BundleInstance",
 			"core.rukpak.io/owner-name": bi.Name,
 		}))
 		objs = append(objs, &obj)

--- a/provisioner/k8s/main.go
+++ b/provisioner/k8s/main.go
@@ -78,7 +78,7 @@ func main() {
 		setupLog.Error(err, "unable to create kubernetes client")
 		os.Exit(1)
 	}
-	dependentRequirement, err := labels.NewRequirement("core.rukpak.io/owner-name", selection.Exists, nil)
+	dependentRequirement, err := labels.NewRequirement("core.rukpak.io/owner-kind", selection.In, []string{"Bundle", "BundleInstance"})
 	if err != nil {
 		setupLog.Error(err, "unable to create dependent label selector for cache")
 		os.Exit(1)


### PR DESCRIPTION
Differentiate between objects owned by bundles and bundleinstances

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>