### PR TITLE
internal,provisioner: Fix how Bundle status conditions are applied

### DIFF
--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -68,8 +68,11 @@ func (u *Updater) Apply(ctx context.Context, b *olmv1alpha1.Bundle) error {
 func EnsureCondition(condition metav1.Condition) UpdateStatusFunc {
 	return func(status *olmv1alpha1.BundleStatus) bool {
 		existing := meta.FindStatusCondition(status.Conditions, condition.Type)
-		meta.SetStatusCondition(&status.Conditions, condition)
-		return existing == nil || !conditionsSemanticallyEqual(*existing, condition)
+		if existing == nil || !conditionsSemanticallyEqual(*existing, condition) {
+			meta.SetStatusCondition(&status.Conditions, condition)
+			return true
+		}
+		return false
 	}
 }
 

--- a/provisioner/k8s/controllers/bundle_controller.go
+++ b/provisioner/k8s/controllers/bundle_controller.go
@@ -132,7 +132,7 @@ func (r *BundleReconciler) handlePendingPod(u *updater.Updater, pod *corev1.Pod)
 		if cStatus.State.Waiting != nil && cStatus.State.Waiting.Reason == "ErrImagePull" {
 			messages = append(messages, cStatus.State.Waiting.Message)
 		}
-		if cStatus.State.Waiting != nil && cStatus.State.Waiting.Reason == "ImagePullBackoff" {
+		if cStatus.State.Waiting != nil && cStatus.State.Waiting.Reason == "ImagePullBackOff" {
 			messages = append(messages, cStatus.State.Waiting.Message)
 		}
 	}


### PR DESCRIPTION
Update the EnsureCondition helper function, and avoid setting the
Bundle's status condition array before checking whether the existing and
new conditions are semantically equal.

Signed-off-by: timflannagan <timflannagan@gmail.com>