### PR TITLE
api,manifests: Add an BundleInstance installation state custom column

### DIFF
--- a/api/v1alpha1/bundleinstance_types.go
+++ b/api/v1alpha1/bundleinstance_types.go
@@ -46,6 +46,7 @@ type BundleInstanceStatus struct {
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Desired Bundle",type=string,JSONPath=`.spec.bundleName`
 //+kubebuilder:printcolumn:name="Installed Bundle",type=string,JSONPath=`.status.installedBundleName`
+//+kubebuilder:printcolumn:name="Install State",type=string,JSONPath=`.status.conditions[?(.type=="Installed")].reason`
 //+kubebuilder:printcolumn:name=Age,type=date,JSONPath=`.metadata.creationTimestamp`
 
 // BundleInstance is the Schema for the bundleinstances API

--- a/manifests/core.rukpak.io_bundleinstances.yaml
+++ b/manifests/core.rukpak.io_bundleinstances.yaml
@@ -21,6 +21,9 @@ spec:
         - jsonPath: .status.installedBundleName
           name: Installed Bundle
           type: string
+        - jsonPath: .status.conditions[?(.type=="Installed")].reason
+          name: Install State
+          type: string
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date


### PR DESCRIPTION
Add a new custom printer column for querying the state of an individual BundleInstance locally.

Example failing Bundle:

```bash
$ k get bundleinstances
NAME       DESIRED BUNDLE     INSTALLED BUNDLE   INSTALL STATE         AGE
olm-crds   olm-v0.20.0-crds   olm-v0.20.0-crds   BundleUnpackPending   13h
```

Example successful Bundle:

```bash
$ k get bundleinstances
NAME       DESIRED BUNDLE     INSTALLED BUNDLE   AGE   INSTALL STATE
olm-crds   olm-v0.20.0-crds   olm-v0.20.0-crds   12h   InstallationSucceeded
```