### PR TITLE
Add basic k8s provisioner Bundle e2e tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,8 +36,18 @@ jobs:
         kind version
         kind create cluster
         kind export kubeconfig
-    - name: Run e2e tests
-      # TODO: Make install has been removed until the Kuberpak manifests are brought in
+    - name: Install the rukpak k8s provisioner
       run: |
-        # make install
+        make generate
+        kubectl create namespace rukpak-system
+        kubectl apply -f manifests
+
+        # Note: run the provisioner in the background so we don't block
+        # running ginkgo tests in the foreground.
+        # TODO: remove this hack when we have k8s provisioner manifests
+        # and more fleshed out CI pipeline that builds/pushes the unpack
+        # and provisioner image(s) so we can reference them at runtime.
+        nohup go run provisioner/k8s/main.go &
+    - name: Run e2e tests
+      run: |
         make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ test-unit: ## Run the unit tests
 	$(Q)go test -count=1 -short $(UNIT_TEST_DIRS)
 
 test-e2e: ginkgo ## Run the e2e tests
-	$(GINKGO) run test/e2e
+	$(GINKGO) -v -trace -progress test/e2e
 
 verify: tidy generate ## Verify the current code generation and lint
 	git diff --exit-code

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -2,12 +2,34 @@ package e2e_test
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/operator-framework/rukpak/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	c client.Client
 )
 
 func TestE2E(t *testing.T) {
 	RegisterFailHandler(Fail)
+	SetDefaultEventuallyTimeout(1 * time.Minute)
+	SetDefaultEventuallyPollingInterval(1 * time.Second)
 	RunSpecs(t, "E2E Suite")
 }
+
+var _ = BeforeSuite(func() {
+	config := ctrl.GetConfigOrDie()
+
+	scheme := runtime.NewScheme()
+	err := v1alpha1.AddToScheme(scheme)
+	Expect(err).To(BeNil())
+
+	c, err = client.New(config, client.Options{Scheme: scheme})
+	Expect(err).To(BeNil())
+})

--- a/test/e2e/k8s_provisioner_test.go
+++ b/test/e2e/k8s_provisioner_test.go
@@ -1,0 +1,74 @@
+package e2e_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/operator-framework/rukpak/api/v1alpha1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("k8s provisioner", func() {
+	var (
+		bundle *v1alpha1.Bundle
+	)
+	BeforeEach(func() {
+		By("creating the testing Bundle resource")
+		bundle = &v1alpha1.Bundle{
+			ObjectMeta: v1.ObjectMeta{
+				Name: "olm-crds",
+			},
+			Spec: v1alpha1.BundleSpec{
+				ProvisionerClassName: "core.rukpak.io/plain",
+				Image:                "quay.io/tflannag/olm-plain-bundle:olm-crds-v0.20.0",
+			},
+		}
+		err := c.Create(context.Background(), bundle)
+		Expect(err).To(BeNil())
+	})
+	AfterEach(func() {
+		By("deleting the testing Bundle resource")
+		Expect(c.Delete(context.Background(), bundle)).To(BeNil())
+	})
+
+	When("a valid Bundle referencing a remote container image is created", func() {
+		It("should eventually report a successful state", func() {
+			By("eventually reporting an Unpacked phase", func() {
+				Eventually(func() bool {
+					if err := c.Get(context.Background(), client.ObjectKeyFromObject(bundle), bundle); err != nil {
+						return false
+					}
+					return bundle.Status.Phase == v1alpha1.PhaseUnpacked
+				}).Should(BeTrue())
+			})
+
+			By("eventually writing a non-empty image digest to the status", func() {
+				Eventually(func() bool {
+					if err := c.Get(context.Background(), client.ObjectKeyFromObject(bundle), bundle); err != nil {
+						return false
+					}
+					// Note(tflannag): This may make the test fairly brittle over time. Let's re-evaluate
+					// whether we want to test this kind of comparison if there's the potential for moving
+					// tags for Bundle container images.
+					expectedDigest := "quay.io/tflannag/olm-plain-bundle@sha256:2a72e4a7bc6c7598d1ecdb2f082c865a91dda35ab8e4a8e8bc128cf49a2a619b"
+					return bundle.Status.Digest == expectedDigest
+				}).Should(BeTrue())
+			})
+
+			By("eventually writing a non-empty list of unpacked objects to the status", func() {
+				Eventually(func() bool {
+					if err := c.Get(context.Background(), client.ObjectKeyFromObject(bundle), bundle); err != nil {
+						return false
+					}
+					if bundle.Status.Info == nil {
+						return false
+					}
+					return len(bundle.Status.Info.Objects) == 8
+				}).Should(BeTrue())
+			})
+		})
+	})
+})


### PR DESCRIPTION
Introduce a barebones Bundle e2e test to ensure we're covering the basic happy path for plain manifest Bundles.