### PR TITLE
.github/workflow: Split up the test workflow into individual jobs

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,14 +8,6 @@ on:
     - main
 
 jobs:
-  unit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '~1.17'
-      - run: make test-unit
   e2e-kind:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,0 +1,18 @@
+name: test
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+    - main
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '~1.17'
+      - run: make test-unit


### PR DESCRIPTION
Update the test.yaml workflow and split the unit and e2e-kind jobs into
their own workflows. This enables the ability to retest them
independently when we encounter a workflow failure as GHA doesn't
support that use case right now.

Signed-off-by: timflannagan <timflannagan@gmail.com>