### PR TITLE
k8s: Update the unpack image initContainer to use the IfNotPresent pull policy

### DIFF
--- a/provisioner/k8s/controllers/bundle_controller.go
+++ b/provisioner/k8s/controllers/bundle_controller.go
@@ -202,7 +202,7 @@ func (r *BundleReconciler) ensureUnpackPod(ctx context.Context, bundle *olmv1alp
 
 	return util.CreateOrRecreate(ctx, r.Client, pod, func() error {
 		pod.SetLabels(map[string]string{
-			"core.rukpak.io/owner-kind": "Bundle",
+			"core.rukpak.io/owner-kind": bundle.Kind,
 			"core.rukpak.io/owner-name": bundle.Name,
 		})
 		pod.SetOwnerReferences([]metav1.OwnerReference{*controllerRef})
@@ -216,6 +216,7 @@ func (r *BundleReconciler) ensureUnpackPod(ctx context.Context, bundle *olmv1alp
 		}
 		pod.Spec.InitContainers[0].Name = "install-cpb"
 		pod.Spec.InitContainers[0].Image = r.UnpackImage
+		pod.Spec.InitContainers[0].ImagePullPolicy = corev1.PullIfNotPresent
 		pod.Spec.InitContainers[0].Command = []string{"cp", "-Rv", "/unpack", "/util/unpack"}
 		pod.Spec.InitContainers[0].VolumeMounts = []corev1.VolumeMount{{Name: "util", MountPath: "/util"}}
 


### PR DESCRIPTION
Explicitly set this IfNotPresent image pull policy for the initContainer that pulls down the configured provisioner unpacking container image, and copies the unpack binary to a volume-mounted directory to workaround scratch base images that don't have shells. By default, the Always image pull policy is used when the container image specified in a Pod uses the `:latest` tag, so if a user explicitly overrides that --unpack-image when running the k8s provisioner, we're left with some implicit behavior.