### PR TITLE
fix: remove run-local target that is no longer being supported

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,6 @@ install-k8s: install-apis ## Install the rukpak CRDs and the k8s provisioner
 
 install: install-k8s ## Install all rukpak core CRDs and provisioners
 
-run-local: install-apis ## Install CRDs and run provisioner locally
-	kubectl create namespace rukpak-system
-	$(Q)go run provisioner/k8s/main.go
-
 deploy: install-apis ## Deploy the operator to the current cluster
 	kubectl apply -f provisioner/k8s/manifests
 


### PR DESCRIPTION
See https://github.com/operator-framework/rukpak/pull/85#discussion_r817995656 for motivation -- this target is no longer being supported, as the supported way of running the provisioner is from within the cluster rather than from outside. 

Signed-off-by: Daniel Sover <dsover@redhat.com>