### PR TITLE
e2e: Surface invalid Bundle container images back to the Bundle status

### DIFF
--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/operator-framework/rukpak/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,6 +29,9 @@ var _ = BeforeSuite(func() {
 
 	scheme := runtime.NewScheme()
 	err := v1alpha1.AddToScheme(scheme)
+	Expect(err).To(BeNil())
+
+	err = corev1.AddToScheme(scheme)
 	Expect(err).To(BeNil())
 
 	c, err = client.New(config, client.Options{Scheme: scheme})

--- a/test/e2e/k8s_provisioner_test.go
+++ b/test/e2e/k8s_provisioner_test.go
@@ -2,39 +2,47 @@ package e2e_test
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"github.com/operator-framework/rukpak/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("k8s provisioner", func() {
-	var (
-		bundle *v1alpha1.Bundle
-	)
-	BeforeEach(func() {
-		By("creating the testing Bundle resource")
-		bundle = &v1alpha1.Bundle{
-			ObjectMeta: v1.ObjectMeta{
-				Name: "olm-crds",
-			},
-			Spec: v1alpha1.BundleSpec{
-				ProvisionerClassName: "core.rukpak.io/plain",
-				Image:                "quay.io/tflannag/olm-plain-bundle:olm-crds-v0.20.0",
-			},
-		}
-		err := c.Create(context.Background(), bundle)
-		Expect(err).To(BeNil())
-	})
-	AfterEach(func() {
-		By("deleting the testing Bundle resource")
-		Expect(c.Delete(context.Background(), bundle)).To(BeNil())
-	})
+func Logf(f string, v ...interface{}) {
+	fmt.Fprintf(GinkgoWriter, f, v...)
+}
 
+var _ = Describe("k8s provisioner", func() {
 	When("a valid Bundle referencing a remote container image is created", func() {
+		var (
+			bundle *v1alpha1.Bundle
+		)
+		BeforeEach(func() {
+			By("creating the testing Bundle resource")
+			bundle = &v1alpha1.Bundle{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "olm-crds",
+				},
+				Spec: v1alpha1.BundleSpec{
+					ProvisionerClassName: "core.rukpak.io/plain",
+					Image:                "quay.io/tflannag/olm-plain-bundle:olm-crds-v0.20.0",
+				},
+			}
+			err := c.Create(context.Background(), bundle)
+			Expect(err).To(BeNil())
+		})
+		AfterEach(func() {
+			By("deleting the testing Bundle resource")
+			Expect(c.Delete(context.Background(), bundle)).To(BeNil())
+		})
+
 		It("should eventually report a successful state", func() {
 			By("eventually reporting an Unpacked phase", func() {
 				Eventually(func() bool {
@@ -69,6 +77,71 @@ var _ = Describe("k8s provisioner", func() {
 					return len(bundle.Status.Info.Objects) == 8
 				}).Should(BeTrue())
 			})
+		})
+	})
+
+	When("an invalid Bundle referencing a remote container image is created", func() {
+		var (
+			bundle *v1alpha1.Bundle
+		)
+		BeforeEach(func() {
+			By("creating the testing Bundle resource")
+			bundle = &v1alpha1.Bundle{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "olm-crds",
+				},
+				Spec: v1alpha1.BundleSpec{
+					ProvisionerClassName: "core.rukpak.io/plain",
+					Image:                "quay.io/tflannag/olm-plain-bundle:non-existent-tag",
+				},
+			}
+			err := c.Create(context.Background(), bundle)
+			Expect(err).To(BeNil())
+		})
+		AfterEach(func() {
+			By("deleting the testing Bundle resource")
+			Expect(c.Delete(context.Background(), bundle)).To(BeNil())
+		})
+
+		It("checks the bundle's phase is stuck in pending", func() {
+			By("waiting until the pod is reporting ImagePullBackOff state")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				if err := c.Get(context.Background(), types.NamespacedName{
+					Name:      fmt.Sprintf("plain-unpack-bundle-%s", bundle.GetName()),
+					Namespace: "rukpak-system",
+				}, pod); err != nil {
+					return false
+				}
+				if pod.Status.Phase != corev1.PodPending {
+					return false
+				}
+				for _, status := range pod.Status.ContainerStatuses {
+					if status.State.Waiting != nil && status.State.Waiting.Reason == "ImagePullBackOff" {
+						return true
+					}
+				}
+				return false
+			}).Should(BeTrue())
+
+			By("waiting for the bundle to report back that state")
+			Eventually(func() bool {
+				err := c.Get(context.Background(), client.ObjectKeyFromObject(bundle), bundle)
+				if err != nil {
+					return false
+				}
+				if bundle.Status.Phase != v1alpha1.PhasePending {
+					return false
+				}
+				unpackPending := meta.FindStatusCondition(bundle.Status.Conditions, v1alpha1.PhaseUnpacked)
+				if unpackPending == nil {
+					return false
+				}
+				if unpackPending.Message != fmt.Sprintf(`Back-off pulling image "%s"`, bundle.Spec.Image) {
+					return false
+				}
+				return true
+			}).Should(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
Add a simple Bundle e2e test that contains an invalid spec.Image container image that doesn't exist, and ensure the Bundle reports back that underlying Pod's status back to the set of Bundle status conditions. This should help avoid regressing on the fixes that went into #77, where we didn't have an e2e structure in place at the time of that PRs' creation.