### PR TITLE
fix: kind-cluster target was failing to remove existing cluster 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ kind-load: ## Load-image loads the currently constructed image onto the cluster
 	${KIND} load docker-image $(IMAGE) --name $(KIND_CLUSTER_NAME)
 
 kind-cluster: ## Standup a kind cluster for e2e testing usage
-ifeq (1, $(shell kind get clusters | grep ${KIND_CLUSTER_NAME} | wc -l))
+ifeq (1, $(shell ${KIND} get clusters | grep ${KIND_CLUSTER_NAME} | wc -l | xargs))
 	@echo "Deleting the existing ${KIND_CLUSTER_NAME} test cluster"
 	${KIND} delete cluster --name ${KIND_CLUSTER_NAME}
 endif


### PR DESCRIPTION
Small PR that fixes the logic in the Makefile `make kind-cluster` target that deletes existing clusters before creating a new one. The existing cluster was not being removed because the whitespace returned from `wc -l` was causing the equality check to fail. Piping the arguments to `xarg` removes any whitespace and causes the equality to return the right result. 