### PR TITLE
build executables locally and package them in an image

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,9 @@
+FROM gcr.io/distroless/static:debug
+
+WORKDIR /
+COPY bin/plain-v0 .
+COPY bin/unpack .
+EXPOSE 8080
+
+ENTRYPOINT ["/plain-v0"]
+CMD ["run"]

--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,11 @@ bin/plain-v0:
 bin/unpack:
 	CGO_ENABLED=0 go build -o $@ ./cmd/unpack/...
 
-build-local-container: ## Builds provisioner container image locally
+build-container: ## Builds provisioner container image locally
 	docker build -f Dockerfile -t $(IMAGE) .
+
+build-local-container: build ## Builds the provisioner container image using locally built binaries
+	docker build -f Dockerfile.local -t $(IMAGE) .
 
 kind-load: ## Load-image loads the currently constructed image onto the cluster
 	${KIND} load docker-image $(IMAGE) --name $(KIND_CLUSTER_NAME)


### PR DESCRIPTION
Signed-off-by: akihikokuroda <akihikokuroda2020@gmail.com>

Closes #98

Add the docker file for the container build and update Makefile to prebuild the executables before container build.