### PR TITLE
ci: Add golangci-lint importas linter configuration

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,5 +21,17 @@ linters:
   - unparam
   - whitespace
 
+linters-settings:
+  importas:
+    alias:
+    - pkg: k8s.io/api/core/v1
+      alias: corev1
+    - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+      alias: metav1
+    - pkg: k8s.io/apimachinery/pkg/api/errors
+      alias: apierrors
+    - pkg: github.com/operator-framework/rukpak/api/v1alpha1
+      alias: rukpakv1alpha1
+
 output:
   format: tab

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	olmv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 )
 
 func New(client client.Client) Updater {
@@ -40,13 +40,13 @@ type Updater struct {
 	updateStatusFuncs []UpdateStatusFunc
 }
 
-type UpdateStatusFunc func(bundle *olmv1alpha1.BundleStatus) bool
+type UpdateStatusFunc func(bundle *rukpakv1alpha1.BundleStatus) bool
 
 func (u *Updater) UpdateStatus(fs ...UpdateStatusFunc) {
 	u.updateStatusFuncs = append(u.updateStatusFuncs, fs...)
 }
 
-func (u *Updater) Apply(ctx context.Context, b *olmv1alpha1.Bundle) error {
+func (u *Updater) Apply(ctx context.Context, b *rukpakv1alpha1.Bundle) error {
 	backoff := retry.DefaultRetry
 
 	return retry.RetryOnConflict(backoff, func() error {
@@ -66,7 +66,7 @@ func (u *Updater) Apply(ctx context.Context, b *olmv1alpha1.Bundle) error {
 }
 
 func EnsureCondition(condition metav1.Condition) UpdateStatusFunc {
-	return func(status *olmv1alpha1.BundleStatus) bool {
+	return func(status *rukpakv1alpha1.BundleStatus) bool {
 		existing := meta.FindStatusCondition(status.Conditions, condition.Type)
 		if existing == nil || !conditionsSemanticallyEqual(*existing, condition) {
 			meta.SetStatusCondition(&status.Conditions, condition)
@@ -81,7 +81,7 @@ func conditionsSemanticallyEqual(a, b metav1.Condition) bool {
 }
 
 func EnsureObservedGeneration(observedGeneration int64) UpdateStatusFunc {
-	return func(status *olmv1alpha1.BundleStatus) bool {
+	return func(status *rukpakv1alpha1.BundleStatus) bool {
 		if status.ObservedGeneration == observedGeneration {
 			return false
 		}
@@ -91,7 +91,7 @@ func EnsureObservedGeneration(observedGeneration int64) UpdateStatusFunc {
 }
 
 func EnsureBundleDigest(digest string) UpdateStatusFunc {
-	return func(status *olmv1alpha1.BundleStatus) bool {
+	return func(status *rukpakv1alpha1.BundleStatus) bool {
 		if status.Digest == digest {
 			return false
 		}
@@ -104,8 +104,8 @@ func UnsetBundleInfo() UpdateStatusFunc {
 	return SetBundleInfo(nil)
 }
 
-func SetBundleInfo(info *olmv1alpha1.BundleInfo) UpdateStatusFunc {
-	return func(status *olmv1alpha1.BundleStatus) bool {
+func SetBundleInfo(info *rukpakv1alpha1.BundleInfo) UpdateStatusFunc {
+	return func(status *rukpakv1alpha1.BundleStatus) bool {
 		if reflect.DeepEqual(status.Info, info) {
 			return false
 		}
@@ -115,7 +115,7 @@ func SetBundleInfo(info *olmv1alpha1.BundleInfo) UpdateStatusFunc {
 }
 
 func SetPhase(phase string) UpdateStatusFunc {
-	return func(status *olmv1alpha1.BundleStatus) bool {
+	return func(status *rukpakv1alpha1.BundleStatus) bool {
 		if status.Phase == phase {
 			return false
 		}

--- a/provisioner/plain-v0/README.md
+++ b/provisioner/plain-v0/README.md
@@ -1,3 +1,3 @@
-# plain-v0 
+# plain-v0
 
 A concrete Provisioner implementation for "plain" k8s bundles.

--- a/provisioner/plain-v0/controllers/bundle_controller.go
+++ b/provisioner/plain-v0/controllers/bundle_controller.go
@@ -41,7 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	olmv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	"github.com/operator-framework/rukpak/internal/storage"
 	"github.com/operator-framework/rukpak/internal/updater"
 	"github.com/operator-framework/rukpak/internal/util"
@@ -82,7 +82,7 @@ func (r *BundleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 	l := log.FromContext(ctx)
 	l.V(1).Info("starting reconciliation")
 	defer l.V(1).Info("ending reconciliation")
-	bundle := &olmv1alpha1.Bundle{}
+	bundle := &rukpakv1alpha1.Bundle{}
 	if err := r.Get(ctx, req.NamespacedName, bundle); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -139,11 +139,11 @@ func (r *BundleReconciler) handlePendingPod(u *updater.Updater, pod *corev1.Pod)
 	u.UpdateStatus(
 		updater.SetBundleInfo(nil),
 		updater.EnsureBundleDigest(""),
-		updater.SetPhase(olmv1alpha1.PhasePending),
+		updater.SetPhase(rukpakv1alpha1.PhasePending),
 		updater.EnsureCondition(metav1.Condition{
-			Type:    olmv1alpha1.TypeUnpacked,
+			Type:    rukpakv1alpha1.TypeUnpacked,
 			Status:  metav1.ConditionFalse,
-			Reason:  olmv1alpha1.ReasonUnpackPending,
+			Reason:  rukpakv1alpha1.ReasonUnpackPending,
 			Message: strings.Join(messages, "; "),
 		}),
 	)
@@ -153,11 +153,11 @@ func (r *BundleReconciler) handleRunningPod(u *updater.Updater) {
 	u.UpdateStatus(
 		updater.SetBundleInfo(nil),
 		updater.EnsureBundleDigest(""),
-		updater.SetPhase(olmv1alpha1.PhaseUnpacking),
+		updater.SetPhase(rukpakv1alpha1.PhaseUnpacking),
 		updater.EnsureCondition(metav1.Condition{
-			Type:   olmv1alpha1.TypeUnpacked,
+			Type:   rukpakv1alpha1.TypeUnpacked,
 			Status: metav1.ConditionFalse,
-			Reason: olmv1alpha1.ReasonUnpacking,
+			Reason: rukpakv1alpha1.ReasonUnpacking,
 		}),
 	)
 }
@@ -166,16 +166,16 @@ func (r *BundleReconciler) handleFailedPod(ctx context.Context, u *updater.Updat
 	u.UpdateStatus(
 		updater.SetBundleInfo(nil),
 		updater.EnsureBundleDigest(""),
-		updater.SetPhase(olmv1alpha1.PhaseFailing),
+		updater.SetPhase(rukpakv1alpha1.PhaseFailing),
 	)
 	logs, err := r.getPodLogs(ctx, pod)
 	if err != nil {
 		err = fmt.Errorf("unpack failed: failed to retrieve failed pod logs: %w", err)
 		u.UpdateStatus(
 			updater.EnsureCondition(metav1.Condition{
-				Type:    olmv1alpha1.TypeUnpacked,
+				Type:    rukpakv1alpha1.TypeUnpacked,
 				Status:  metav1.ConditionFalse,
-				Reason:  olmv1alpha1.ReasonUnpackFailed,
+				Reason:  rukpakv1alpha1.ReasonUnpackFailed,
 				Message: err.Error(),
 			}),
 		)
@@ -184,9 +184,9 @@ func (r *BundleReconciler) handleFailedPod(ctx context.Context, u *updater.Updat
 	logStr := string(logs)
 	u.UpdateStatus(
 		updater.EnsureCondition(metav1.Condition{
-			Type:    olmv1alpha1.TypeUnpacked,
+			Type:    rukpakv1alpha1.TypeUnpacked,
 			Status:  metav1.ConditionFalse,
-			Reason:  olmv1alpha1.ReasonUnpackFailed,
+			Reason:  rukpakv1alpha1.ReasonUnpackFailed,
 			Message: logStr,
 		}),
 	)
@@ -194,7 +194,7 @@ func (r *BundleReconciler) handleFailedPod(ctx context.Context, u *updater.Updat
 	return fmt.Errorf("unpack failed: %v", logStr)
 }
 
-func (r *BundleReconciler) ensureUnpackPod(ctx context.Context, bundle *olmv1alpha1.Bundle, pod *corev1.Pod) (controllerutil.OperationResult, error) {
+func (r *BundleReconciler) ensureUnpackPod(ctx context.Context, bundle *rukpakv1alpha1.Bundle, pod *corev1.Pod) (controllerutil.OperationResult, error) {
 	controllerRef := metav1.NewControllerRef(bundle, bundle.GroupVersionKind())
 	automountServiceAccountToken := false
 	pod.SetName(util.PodName("plain", bundle.Name))
@@ -236,29 +236,29 @@ func updateStatusUnpackPending(u *updater.Updater) {
 	u.UpdateStatus(
 		updater.SetBundleInfo(nil),
 		updater.EnsureBundleDigest(""),
-		updater.SetPhase(olmv1alpha1.PhasePending),
+		updater.SetPhase(rukpakv1alpha1.PhasePending),
 		updater.EnsureCondition(metav1.Condition{
-			Type:   olmv1alpha1.TypeUnpacked,
+			Type:   rukpakv1alpha1.TypeUnpacked,
 			Status: metav1.ConditionFalse,
-			Reason: olmv1alpha1.ReasonUnpackPending,
+			Reason: rukpakv1alpha1.ReasonUnpackPending,
 		}),
 	)
 }
 
 func updateStatusUnpackFailing(u *updater.Updater, err error) error {
 	u.UpdateStatus(
-		updater.SetPhase(olmv1alpha1.PhaseFailing),
+		updater.SetPhase(rukpakv1alpha1.PhaseFailing),
 		updater.EnsureCondition(metav1.Condition{
-			Type:    olmv1alpha1.TypeUnpacked,
+			Type:    rukpakv1alpha1.TypeUnpacked,
 			Status:  metav1.ConditionFalse,
-			Reason:  olmv1alpha1.ReasonUnpackFailed,
+			Reason:  rukpakv1alpha1.ReasonUnpackFailed,
 			Message: err.Error(),
 		}),
 	)
 	return err
 }
 
-func (r *BundleReconciler) handleCompletedPod(ctx context.Context, u *updater.Updater, bundle *olmv1alpha1.Bundle, pod *corev1.Pod) error {
+func (r *BundleReconciler) handleCompletedPod(ctx context.Context, u *updater.Updater, bundle *rukpakv1alpha1.Bundle, pod *corev1.Pod) error {
 	bundleFS, err := r.getBundleContents(ctx, pod)
 	if err != nil {
 		return updateStatusUnpackFailing(u, fmt.Errorf("get bundle contents: %w", err))
@@ -278,10 +278,10 @@ func (r *BundleReconciler) handleCompletedPod(ctx context.Context, u *updater.Up
 		return updateStatusUnpackFailing(u, fmt.Errorf("persist bundle objects: %w", err))
 	}
 
-	info := &olmv1alpha1.BundleInfo{}
+	info := &rukpakv1alpha1.BundleInfo{}
 	for _, obj := range objects {
 		gvk := obj.GetObjectKind().GroupVersionKind()
-		info.Objects = append(info.Objects, olmv1alpha1.BundleObject{
+		info.Objects = append(info.Objects, rukpakv1alpha1.BundleObject{
 			Group:     gvk.Group,
 			Version:   gvk.Version,
 			Kind:      gvk.Kind,
@@ -293,11 +293,11 @@ func (r *BundleReconciler) handleCompletedPod(ctx context.Context, u *updater.Up
 	u.UpdateStatus(
 		updater.SetBundleInfo(info),
 		updater.EnsureBundleDigest(bundleImageDigest),
-		updater.SetPhase(olmv1alpha1.PhaseUnpacked),
+		updater.SetPhase(rukpakv1alpha1.PhaseUnpacked),
 		updater.EnsureCondition(metav1.Condition{
-			Type:   olmv1alpha1.TypeUnpacked,
+			Type:   rukpakv1alpha1.TypeUnpacked,
 			Status: metav1.ConditionTrue,
-			Reason: olmv1alpha1.ReasonUnpackSuccessful,
+			Reason: rukpakv1alpha1.ReasonUnpackSuccessful,
 		}),
 	)
 
@@ -378,7 +378,7 @@ func getObjects(bundleFS fs.FS) ([]client.Object, error) {
 // SetupWithManager sets up the controller with the Manager.
 func (r *BundleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&olmv1alpha1.Bundle{}, builder.WithPredicates(
+		For(&rukpakv1alpha1.Bundle{}, builder.WithPredicates(
 			bundleProvisionerFilter(plainBundleProvisionerID),
 		)).
 		Owns(&corev1.Secret{}).
@@ -389,7 +389,7 @@ func (r *BundleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func bundleProvisionerFilter(provisionerClassName string) predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
-		b := obj.(*olmv1alpha1.Bundle)
+		b := obj.(*rukpakv1alpha1.Bundle)
 		return b.Spec.ProvisionerClassName == provisionerClassName
 	})
 }

--- a/provisioner/plain-v0/main.go
+++ b/provisioner/plain-v0/main.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	olmv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	"github.com/operator-framework/rukpak/internal/storage"
 	"github.com/operator-framework/rukpak/internal/util"
 	"github.com/operator-framework/rukpak/provisioner/plain-v0/controllers"
@@ -47,7 +47,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
-	utilruntime.Must(olmv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(rukpakv1alpha1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 
@@ -93,8 +93,8 @@ func main() {
 		LeaderElectionID:       "510f803c.olm.operatorframework.io",
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			SelectorsByObject: cache.SelectorsByObject{
-				&olmv1alpha1.BundleInstance{}: {},
-				&olmv1alpha1.Bundle{}:         {},
+				&rukpakv1alpha1.BundleInstance{}: {},
+				&rukpakv1alpha1.Bundle{}:         {},
 			},
 			DefaultSelector: cache.ObjectSelector{
 				Label: dependentSelector,

--- a/test/e2e/plain-v0_provisioner_test.go
+++ b/test/e2e/plain-v0_provisioner_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/operator-framework/rukpak/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
@@ -34,7 +34,7 @@ var _ = Describe("plain-v0 provisioner", func() {
 		BeforeEach(func() {
 			By("creating the testing Bundle resource")
 			bundle = &v1alpha1.Bundle{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "olm-crds",
 				},
 				Spec: v1alpha1.BundleSpec{
@@ -134,7 +134,7 @@ var _ = Describe("plain-v0 provisioner", func() {
 		BeforeEach(func() {
 			By("creating the testing Bundle resource")
 			bundle = &v1alpha1.Bundle{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "olm-crds",
 				},
 				Spec: v1alpha1.BundleSpec{


### PR DESCRIPTION
Update the .golangci.yaml file and introduce a basic importas linter configuration to enforce common package imports (corev1, metav1, etc.) throughout the codebase.