### PR TITLE
add version information to rukpak built binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ COPY cmd cmd
 COPY api api
 COPY internal internal
 COPY provisioner provisioner
+# copy git-related information for binary version information
+COPY .git/HEAD .git/HEAD
+COPY .git/refs/heads/. .git/refs/heads
+RUN mkdir -p .git/objects
+
 RUN make build
 
 FROM gcr.io/distroless/static:debug

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,31 @@
+###########################
+# Configuration Variables #
+###########################
+ORG := github.com/operator-framework
+PKG := $(ORG)/rukpak
+IMAGE_REPO=quay.io/operator-framework/plain-v0-provisioner
+IMAGE_TAG=latest
+IMAGE=$(IMAGE_REPO):$(IMAGE_TAG)
+KIND_CLUSTER_NAME ?= kind
+KIND := kind
+VERSION_PATH := $(PKG)/internal/version
+GIT_COMMIT ?= $(shell git rev-parse HEAD)
+PKGS = $(shell go list ./...)
 
+# kernel-style V=1 build verbosity
+ifeq ("$(origin V)", "command line")
+  BUILD_VERBOSE = $(V)
+endif
+
+ifeq ($(BUILD_VERBOSE),1)
+  Q =
+else
+  Q = @
+endif
+
+###############
+# Help Target #
+###############
 .PHONY: help
 help: ## Show this help screen
 	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
@@ -7,36 +34,36 @@ help: ## Show this help screen
 	@echo ''
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-# Container build options
-IMAGE_REPO=quay.io/operator-framework/plain-v0-provisioner
-IMAGE_TAG=latest
-IMAGE=$(IMAGE_REPO):$(IMAGE_TAG)
+###################
+# Code management #
+###################
+.PHONY: lint tidy clean generate verify
 
-KIND_CLUSTER_NAME ?= kind
-KIND := kind
+##@ code management:
 
-# Code management
-.PHONY: lint tidy clean generate
-
-PKGS = $(shell go list ./...)
-
-lint: golangci-lint
+lint: golangci-lint ## Run golangci linter
 	$(Q)$(GOLANGCI_LINT) run
 
 tidy: ## Update dependencies
 	$(Q)go mod tidy
+
+clean: ## Remove binaries and test artifacts
+	@rm -rf bin
 
 generate: controller-gen ## Generate code and manifests
 	$(Q)$(CONTROLLER_GEN) crd:crdVersions=v1 output:crd:dir=./manifests paths=./api/...
 	$(Q)$(CONTROLLER_GEN) schemapatch:manifests=./manifests output:dir=./manifests paths=./api/...
 	$(Q)$(CONTROLLER_GEN) object:headerFile=./hack/boilerplate.go.txt paths=./api/...
 
+verify: tidy generate ## Verify the current code generation and lint
+	git diff --exit-code
 
-## --------------------------------------
-## Testing and Verification
-## --------------------------------------
-# Static tests.
-.PHONY: test test-unit verify
+###########
+# Testing #
+###########
+.PHONY: test test-unit test-e2e
+
+##@ testing:
 
 test: test-unit test-e2e ## Run the tests
 
@@ -47,12 +74,13 @@ test-unit: ## Run the unit tests
 test-e2e: ginkgo ## Run the e2e tests
 	$(GINKGO) -v -trace -progress test/e2e
 
-verify: tidy generate ## Verify the current code generation and lint
-	git diff --exit-code
+###################
+# Install and Run #
+###################
+.PHONY: install-apis install-plain-v0 install deploy run
 
-## --------------------------------------
-## Install and Run
-## --------------------------------------
+##@ install/run:
+
 install-apis: generate ## Install the core rukpak CRDs
 	kubectl apply -f manifests
 
@@ -66,20 +94,23 @@ deploy: install-apis ## Deploy the operator to the current cluster
 
 run: build-local-container kind-load deploy ## Build image and run operator in-cluster
 
-## --------------------------------------
-## Build and Load
-## --------------------------------------
-.PHONY: build bin/plain-v0 bin/unpack
+##################
+# Build and Load #
+##################
+.PHONY: build bin/plain-v0 bin/unpack build-local-container kind-load kind-cluster
+
+##@ build/load:
 
 # Binary builds
 GO_BUILD := $(Q)go build
+VERSION_FLAGS=-ldflags "-X $(VERSION_PATH).GitCommit=$(GIT_COMMIT)"
 build: bin/plain-v0 bin/unpack
 
 bin/plain-v0:
-	CGO_ENABLED=0 go build -o $@$(BIN_SUFFIX) ./provisioner/plain-v0
+	CGO_ENABLED=0 go build $(VERSION_FLAGS) -o $@$(BIN_SUFFIX) ./provisioner/plain-v0
 
 bin/unpack:
-	CGO_ENABLED=0 go build -o $@$(BIN_SUFFIX) ./cmd/unpack/...
+	CGO_ENABLED=0 go build $(VERSION_FLAGS) -o $@$(BIN_SUFFIX) ./cmd/unpack/...
 
 build-container: ## Builds provisioner container image locally
 	docker build -f Dockerfile -t $(IMAGE) .
@@ -99,9 +130,9 @@ kind-cluster: ## Standup a kind cluster for e2e testing usage
 e2e: KIND_CLUSTER_NAME=rukpak-e2e
 e2e: build-container kind-cluster kind-load deploy test-e2e ## Run e2e tests against a kind cluster
 
-## --------------------------------------
-## Hack / Tools
-## --------------------------------------
+################
+# Hack / Tools #
+################
 BIN_DIR := bin
 TOOLS_DIR := hack/tools
 TOOLS_BIN_DIR := $(TOOLS_DIR)/bin

--- a/cmd/unpack/main.go
+++ b/cmd/unpack/main.go
@@ -7,16 +7,23 @@ import (
 	"log"
 	"os"
 
+	"github.com/operator-framework/rukpak/internal/version"
+
 	"github.com/spf13/cobra"
 )
 
 func main() {
 	var bundleDir string
+	var rukpakVersion bool
 
 	cmd := &cobra.Command{
 		Use:  "unpack",
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if rukpakVersion {
+				fmt.Printf("Git commit: %s\n", version.String())
+				os.Exit(0)
+			}
 			bundleFS := os.DirFS(bundleDir)
 			bundleContents := map[string][]byte{}
 			if err := fs.WalkDir(bundleFS, ".", func(path string, d fs.DirEntry, err error) error {
@@ -44,6 +51,8 @@ func main() {
 		},
 	}
 	cmd.Flags().StringVar(&bundleDir, "bundle-dir", "", "directory in which the bundle can be found")
+	cmd.Flags().BoolVar(&rukpakVersion, "version", false, "displays rukpak version information")
+
 	if err := cmd.Execute(); err != nil {
 		log.Fatal(err)
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,8 @@
+package version
+
+// GitCommit indicates which commit the rukpak binaries were built from
+var GitCommit string
+
+func String() string {
+	return GitCommit
+}

--- a/provisioner/plain-v0/main.go
+++ b/provisioner/plain-v0/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	helmclient "github.com/operator-framework/helm-operator-plugins/pkg/client"
@@ -36,6 +37,7 @@ import (
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	"github.com/operator-framework/rukpak/internal/storage"
 	"github.com/operator-framework/rukpak/internal/util"
+	"github.com/operator-framework/rukpak/internal/version"
 	"github.com/operator-framework/rukpak/provisioner/plain-v0/controllers"
 )
 
@@ -57,6 +59,7 @@ func main() {
 	var probeAddr string
 	var systemNamespace string
 	var unpackImage string
+	var rukpakVersion bool
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&systemNamespace, "system-namespace", "rukpak-system", "Configures the namespace that gets used to deploy system resources.")
@@ -64,13 +67,20 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&rukpakVersion, "version", false, "Displays rukpak version information")
 	opts := zap.Options{
 		Development: true,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
+	if rukpakVersion {
+		fmt.Printf("Git commit: %s\n", version.String())
+		os.Exit(0)
+	}
+
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	setupLog.Info("starting up the provisioner", "Git commit", version.String())
 
 	cfg := ctrl.GetConfigOrDie()
 	kubeClient, err := kubernetes.NewForConfig(cfg)


### PR DESCRIPTION
This PR cleans up the Makefile to make it more consistent, and adds a version flag to the binaries that are produced in rukpak: the unpack binary and the plain-v0-provisioner binary. This version information will be helpful as development accelerates and encoding version information in the binary will be useful when debugging. 

```
$ ./bin/plain-v0 --version
Git commit: ba0e6da94d140e7e8b2780bc4f9a541d7f2ccdc8
```