### PR TITLE
Makefile: Fix the run target to use the renamed kind-load target as a prequisite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ install: install-plain-v0 ## Install all rukpak core CRDs and provisioners
 deploy: install-apis ## Deploy the operator to the current cluster
 	kubectl apply -f provisioner/plain-v0/manifests
 
-run: build-local-container load-image deploy ## Build image and run operator in-cluster
+run: build-local-container kind-load deploy ## Build image and run operator in-cluster
 
 ## --------------------------------------
 ## Build and Load


### PR DESCRIPTION
The `load-image` Makefile target was renamed during the changes needed
to streamline our e2e experience. This target is now named `kind-load`
to match the other kind-* related targets.

Signed-off-by: timflannagan <timflannagan@gmail.com>