### PR TITLE
add internal/helm-operator-plugins/dependent.go unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/operator-framework/api v0.13.0
 	github.com/operator-framework/helm-operator-plugins v0.0.9
 	github.com/spf13/cobra v1.3.0
+	github.com/stretchr/testify v1.7.0
 	helm.sh/helm/v3 v3.8.0
 	k8s.io/api v0.23.1
 	k8s.io/apiextensions-apiserver v0.23.1
@@ -114,7 +115,6 @@ require (
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect

--- a/internal/helm-operator-plugins/predicate/depedent_test.go
+++ b/internal/helm-operator-plugins/predicate/depedent_test.go
@@ -1,0 +1,132 @@
+package predicate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func TestDependentPredicateFuncsCreate(t *testing.T) {
+	for _, tt := range []struct {
+		description string
+		arg         event.CreateEvent
+		result      bool
+	}{
+		{
+			description: "Happy path - return false for Create event",
+			arg: event.CreateEvent{
+				Object: &unstructured.Unstructured{
+					Object: map[string]interface{}{"key": "Value"},
+				},
+			},
+			result: false,
+		},
+	} {
+		t.Run(tt.description, func(t *testing.T) {
+			funcs := DependentPredicateFuncs()
+			result := funcs.CreateFunc(tt.arg)
+			require.Equal(t, tt.result, result)
+		})
+	}
+}
+
+func TestDependentPredicateFuncsDelete(t *testing.T) {
+	for _, tt := range []struct {
+		description string
+		arg         event.DeleteEvent
+		result      bool
+	}{
+		{
+			description: "Happy path - return true for Delete event",
+			arg: event.DeleteEvent{
+				Object: &unstructured.Unstructured{
+					Object: map[string]interface{}{"key": "Value"},
+				},
+			},
+			result: true,
+		},
+	} {
+		t.Run(tt.description, func(t *testing.T) {
+			funcs := DependentPredicateFuncs()
+			result := funcs.DeleteFunc(tt.arg)
+			require.Equal(t, tt.result, result)
+		})
+	}
+}
+
+func TestDependentPredicateFuncsGeneric(t *testing.T) {
+	for _, tt := range []struct {
+		description string
+		arg         event.GenericEvent
+		result      bool
+	}{
+		{
+			description: "Happy path - return false for Generic event",
+			arg: event.GenericEvent{
+				Object: &unstructured.Unstructured{
+					Object: map[string]interface{}{"key": "Value"},
+				},
+			},
+			result: false,
+		},
+	} {
+		t.Run(tt.description, func(t *testing.T) {
+			funcs := DependentPredicateFuncs()
+			result := funcs.GenericFunc(tt.arg)
+			require.Equal(t, tt.result, result)
+		})
+	}
+}
+
+func TestDependentPredicateFuncsUpdate(t *testing.T) {
+	for _, tt := range []struct {
+		description string
+		arg         event.UpdateEvent
+		result      bool
+	}{
+		{
+			description: "No update - return false",
+			arg: event.UpdateEvent{
+				ObjectOld: &unstructured.Unstructured{
+					Object: map[string]interface{}{"key": "Value", "status": "statusValue"},
+				},
+				ObjectNew: &unstructured.Unstructured{
+					Object: map[string]interface{}{"key": "Value", "status": "statusValue"},
+				},
+			},
+			result: false,
+		},
+		{
+			description: "No update with status difference - return false ignoring status differences",
+			arg: event.UpdateEvent{
+				ObjectOld: &unstructured.Unstructured{
+					Object: map[string]interface{}{"key": "Value", "status": "oldstatusValue"},
+				},
+				ObjectNew: &unstructured.Unstructured{
+					Object: map[string]interface{}{"key": "Value", "status": "newstatusValue"},
+				},
+			},
+			result: false,
+		},
+		{
+			description: "With update - return true",
+			arg: event.UpdateEvent{
+				ObjectOld: &unstructured.Unstructured{
+					Object: map[string]interface{}{"key": "Value", "status": "statusValue"},
+				},
+				ObjectNew: &unstructured.Unstructured{
+					Object: map[string]interface{}{"key": "Value1", "status": "statusValue"},
+				},
+			},
+			result: true,
+		},
+	} {
+		t.Run(tt.description, func(t *testing.T) {
+			funcs := DependentPredicateFuncs()
+			result := funcs.UpdateFunc(tt.arg)
+			require.Equal(t, tt.result, result)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: akihikokuroda <akihikokuroda2020@gmail.com>

Add unit tests for internal/helm-operator-plugins/predicate/dependent.go