### PR TITLE
fix: specify linux build flag for make build-local-container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ bin/unpack:
 build-container: ## Builds provisioner container image locally
 	docker build -f Dockerfile -t $(IMAGE) .
 
+build-local-container: export GOOS=linux
 build-local-container: build ## Builds the provisioner container image using locally built binaries
 	docker build -f Dockerfile.local -t $(IMAGE) .
 


### PR DESCRIPTION
Building the local Dockerfile fails on non-linux machines since no GOOS or GOARCH variables are specificied to make build, which causes execution to fail. For example, building the binaries locally on macOS, then putting them in a `gcr.io/distroless/static:debug` linux based image, we see `standard_init_linux.go:228: exec user process caused: exec format` error on startup. This PR sets the default build GOOS flag to linux when building the container locally.