### PR TITLE
Makefile: Update the e2e target to use the build-container as a prereq

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ ifeq (1, $(shell kind get clusters | grep ${KIND_CLUSTER_NAME} | wc -l))
 endif
 	${KIND} create cluster --name ${KIND_CLUSTER_NAME}
 
-e2e: build-local-container kind-cluster kind-load deploy test-e2e ## Run e2e tests against a kind cluster
+e2e: build-container kind-cluster kind-load deploy test-e2e ## Run e2e tests against a kind cluster
 
 ## --------------------------------------
 ## Hack / Tools


### PR DESCRIPTION
Update the e2e target and replace the build-local-container ->
build-container targets to ensure that CI is building the root
Dockerfile and using that throughout CI.

Signed-off-by: timflannagan <timflannagan@gmail.com>