### PR TITLE
ci(deploy): add new workflow for deploying image with main tag

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,27 @@
+name: deploy
+
+on:
+  push:
+    branches:
+    - main
+
+jobs: 
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Login to quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: quay.io/operator-framework/plain-v0-provisioner:main
+

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -8,7 +8,7 @@ on:
     - main
 
 jobs:
-  sanity:
+  verify:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Adding a new action that pushes a new `main` tagged image to our quay repository on a push to `main`. There is a follow-up PR coming that will also do this on `release` which will create a semantically-version tagged image.

*Note* this will continue to fail until we add the required secrets to this repository. I didn't have the permission to do this.

Closes #91 