### PR TITLE
Makefile: only run 'kind' when necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,10 +91,7 @@ kind-load: ## Load-image loads the currently constructed image onto the cluster
 	${KIND} load docker-image $(IMAGE) --name $(KIND_CLUSTER_NAME)
 
 kind-cluster: ## Standup a kind cluster for e2e testing usage
-ifeq (1, $(shell ${KIND} get clusters | grep ${KIND_CLUSTER_NAME} | wc -l | xargs))
-	@echo "Deleting the existing ${KIND_CLUSTER_NAME} test cluster"
 	${KIND} delete cluster --name ${KIND_CLUSTER_NAME}
-endif
 	${KIND} create cluster --name ${KIND_CLUSTER_NAME}
 
 e2e: build-container kind-cluster kind-load deploy test-e2e ## Run e2e tests against a kind cluster


### PR DESCRIPTION
The `ifeq` block in the Makefile controlling access to the `kind` delete call is executed when the Makefile is parsed. This causes the Makefile to take longer to evaluate and it is confusing to see something like "kind: command not found" in the output of an unrelated task.

Before:
```
$ make generate
/bin/sh: kind: command not found
...
```

After:
```
$ make generate
...
```

This PR just forcefully calls `kind delete cluster`, which happily succeeds if the named cluster is non-existent.

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>