### PR TITLE
fix: add back * RBAC rules to successfully install arbitrary manifests

### DIFF
--- a/provisioner/plain-v0/manifests/01_cluster_role.yaml
+++ b/provisioner/plain-v0/manifests/01_cluster_role.yaml
@@ -3,15 +3,6 @@ kind: ClusterRole
 metadata:
   name: plain-v0-provisioner-admin
 rules:
-- apiGroups: ["core.rukpak.io"]
+- apiGroups: ["*"]
   resources: ["*"]
-  verbs: ["*"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["*"]
-- apiGroups: [""]
-  resources: ["*"]
-  verbs: ["*"]
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["clusterroles", "roles"]
   verbs: ["*"]

--- a/provisioner/plain-v0/manifests/02_role.yaml
+++ b/provisioner/plain-v0/manifests/02_role.yaml
@@ -4,9 +4,6 @@ metadata:
   name: plain-v0-provisioner-admin
   namespace: rukpak-system
 rules:
-- apiGroups: [""]
+- apiGroups: ["*"]
   resources: ["*"]
-  verbs: ["*"]
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["roles"]
   verbs: ["*"]


### PR DESCRIPTION
Adds * RBAC rules to the provisioner to install combo successfully -- this is part of the documentation work, since in the plain-v0 provisioner docs we use combo as an example bundle to install. 
