### PR TITLE
add optional GOOS tag to built binaries to specify linux build for build-local-container

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,8 +1,8 @@
 FROM gcr.io/distroless/static:debug
 
 WORKDIR /
-COPY bin/plain-v0 .
-COPY bin/unpack .
+COPY bin/plain-v0-linux plain-v0
+COPY bin/unpack-linux unpack
 EXPOSE 8080
 
 ENTRYPOINT ["/plain-v0"]

--- a/Makefile
+++ b/Makefile
@@ -76,15 +76,16 @@ GO_BUILD := $(Q)go build
 build: bin/plain-v0 bin/unpack
 
 bin/plain-v0:
-	CGO_ENABLED=0 go build -o $@ ./provisioner/plain-v0
+	CGO_ENABLED=0 go build -o $@$(BIN_SUFFIX) ./provisioner/plain-v0
 
 bin/unpack:
-	CGO_ENABLED=0 go build -o $@ ./cmd/unpack/...
+	CGO_ENABLED=0 go build -o $@$(BIN_SUFFIX) ./cmd/unpack/...
 
 build-container: ## Builds provisioner container image locally
 	docker build -f Dockerfile -t $(IMAGE) .
 
 build-local-container: export GOOS=linux
+build-local-container: BIN_SUFFIX=-$(GOOS)
 build-local-container: build ## Builds the provisioner container image using locally built binaries
 	docker build -f Dockerfile.local -t $(IMAGE) .
 


### PR DESCRIPTION
This PR changes the `make build` target to name the binary with a GOOS suffix to indicate that the binary is for linux systems when `make build-local-container` is ran. This change does not affect the binary name when building locally via `make build` and GOOS is not set. 