### PR TITLE
fix: use default kind cluster name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ IMAGE_REPO=quay.io/operator-framework/plain-v0-provisioner
 IMAGE_TAG=latest
 IMAGE=$(IMAGE_REPO):$(IMAGE_TAG)
 
-KIND_CLUSTER_NAME := rukpak-e2e
+KIND_CLUSTER_NAME ?= kind
 KIND := kind
 
 # Code management
@@ -95,6 +95,7 @@ kind-cluster: ## Standup a kind cluster for e2e testing usage
 	${KIND} delete cluster --name ${KIND_CLUSTER_NAME}
 	${KIND} create cluster --name ${KIND_CLUSTER_NAME}
 
+e2e: KIND_CLUSTER_NAME=rukpak-e2e
 e2e: build-container kind-cluster kind-load deploy test-e2e ## Run e2e tests against a kind cluster
 
 ## --------------------------------------


### PR DESCRIPTION
This PR updates the default name of the kind cluster being used so that non-e2e targets can succeed. Currently  `make run` expects there to be a kind cluster named "rukpak-e2e" to be available, which is unexpected. This is due to the `kind-load` target referencing the cluster name. By changing the default name of the expected cluster to kind, but still preserving the rukpak-e2e cluster name for the `make e2e` target specifically, we give users a more intuitive local experience while preserving the hermetic e2e workflow. 