### PR TITLE
ci: Update the e2e and unit workflows to use unique names

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,4 +1,4 @@
-name: test
+name: e2e
 
 on:
   workflow_dispatch:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,4 +1,4 @@
-name: test
+name: unit
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Update the e2e.yaml and unit.yaml workflows and avoid using the same
`test` workflow name so it's easier to distinguish in the github UI.

See the current view in the UI:

![Screenshot from 2022-03-15 10-54-57](https://user-images.githubusercontent.com/9899409/158405778-d59d9053-d74d-4522-b90b-a965f4e7ceca.png)

Signed-off-by: timflannagan <timflannagan@gmail.com>