### PR TITLE
feat(plain): improve user-experience around BundleInstances that reference a deleted Bundle

### DIFF
--- a/api/v1alpha1/bundleinstance_types.go
+++ b/api/v1alpha1/bundleinstance_types.go
@@ -23,6 +23,23 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+const (
+	TypeHasValidBundle       = "HasValidBundle"
+	TypeInvalidBundleContent = "InvalidBundleContent"
+	TypeInstalled            = "Installed"
+
+	ReasonBundleLookupFailed       = "BundleLookupFailed"
+	ReasonBundleLoadFailed         = "BundleLoadFailed"
+	ReasonReadingContentFailed     = "ReadingContentFailed"
+	ReasonErrorGettingClient       = "ErrorGettingClient"
+	ReasonErrorGettingReleaseState = "ErrorGettingReleaseState"
+	ReasonInstallFailed            = "InstallFailed"
+	ReasonUpgradeFailed            = "UpgradeFailed"
+	ReasonReconcileFailed          = "ReconcileFailed"
+	ReasonCreateDynamicWatchFailed = "CreateDynamicWatchFailed"
+	ReasonInstallationSucceeded    = "InstallationSucceeded"
+)
+
 // BundleInstanceSpec defines the desired state of BundleInstance
 type BundleInstanceSpec struct {
 	// ProvisionerClassName sets the name of the provisioner that should reconcile this BundleInstance.

--- a/internal/provisioner/plain/controllers/bundleinstance_controller.go
+++ b/internal/provisioner/plain/controllers/bundleinstance_controller.go
@@ -108,9 +108,9 @@ func (r *BundleInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			bundleStatus = metav1.ConditionFalse
 		}
 		meta.SetStatusCondition(&bi.Status.Conditions, metav1.Condition{
-			Type:    "HasValidBundle",
+			Type:    rukpakv1alpha1.TypeHasValidBundle,
 			Status:  bundleStatus,
-			Reason:  "BundleLookupFailed",
+			Reason:  rukpakv1alpha1.ReasonBundleLookupFailed,
 			Message: err.Error(),
 		})
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -125,16 +125,16 @@ func (r *BundleInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				reason = "BundleUnpackRunning"
 			}
 			meta.SetStatusCondition(&bi.Status.Conditions, metav1.Condition{
-				Type:   "Installed",
+				Type:   rukpakv1alpha1.TypeInstalled,
 				Status: metav1.ConditionFalse,
 				Reason: reason,
 			})
 			return ctrl.Result{}, nil
 		}
 		meta.SetStatusCondition(&bi.Status.Conditions, metav1.Condition{
-			Type:    "HasValidBundle",
+			Type:    rukpakv1alpha1.TypeHasValidBundle,
 			Status:  metav1.ConditionFalse,
-			Reason:  "BundleLoadFailed",
+			Reason:  rukpakv1alpha1.ReasonBundleLoadFailed,
 			Message: err.Error(),
 		})
 		return ctrl.Result{}, err
@@ -147,9 +147,9 @@ func (r *BundleInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		jsonData, err := yaml.Marshal(obj)
 		if err != nil {
 			meta.SetStatusCondition(&bi.Status.Conditions, metav1.Condition{
-				Type:    "InvalidBundleContent",
+				Type:    rukpakv1alpha1.TypeInvalidBundleContent,
 				Status:  metav1.ConditionTrue,
-				Reason:  "ReadingContentFailed",
+				Reason:  rukpakv1alpha1.ReasonReadingContentFailed,
 				Message: err.Error(),
 			})
 			return ctrl.Result{}, err
@@ -166,9 +166,9 @@ func (r *BundleInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	bi.SetNamespace("")
 	if err != nil {
 		meta.SetStatusCondition(&bi.Status.Conditions, metav1.Condition{
-			Type:    "Installed",
+			Type:    rukpakv1alpha1.TypeInstalled,
 			Status:  metav1.ConditionFalse,
-			Reason:  "ErrorGettingClient",
+			Reason:  rukpakv1alpha1.ReasonErrorGettingClient,
 			Message: err.Error(),
 		})
 		return ctrl.Result{}, err
@@ -177,9 +177,9 @@ func (r *BundleInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	rel, state, err := r.getReleaseState(cl, bi, chrt)
 	if err != nil {
 		meta.SetStatusCondition(&bi.Status.Conditions, metav1.Condition{
-			Type:    "Installed",
+			Type:    rukpakv1alpha1.TypeInstalled,
 			Status:  metav1.ConditionFalse,
-			Reason:  "ErrorGettingReleaseState",
+			Reason:  rukpakv1alpha1.ReasonErrorGettingReleaseState,
 			Message: err.Error(),
 		})
 		return ctrl.Result{}, err
@@ -193,9 +193,9 @@ func (r *BundleInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		})
 		if err != nil {
 			meta.SetStatusCondition(&bi.Status.Conditions, metav1.Condition{
-				Type:    "Installed",
+				Type:    rukpakv1alpha1.TypeInstalled,
 				Status:  metav1.ConditionFalse,
-				Reason:  "InstallFailed",
+				Reason:  rukpakv1alpha1.ReasonInstallFailed,
 				Message: err.Error(),
 			})
 			return ctrl.Result{}, err
@@ -204,9 +204,9 @@ func (r *BundleInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		_, err = cl.Upgrade(bi.Name, r.ReleaseNamespace, chrt, nil)
 		if err != nil {
 			meta.SetStatusCondition(&bi.Status.Conditions, metav1.Condition{
-				Type:    "Installed",
+				Type:    rukpakv1alpha1.TypeInstalled,
 				Status:  metav1.ConditionFalse,
-				Reason:  "UpgradeFailed",
+				Reason:  rukpakv1alpha1.ReasonUpgradeFailed,
 				Message: err.Error(),
 			})
 			return ctrl.Result{}, err
@@ -214,9 +214,9 @@ func (r *BundleInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	case stateUnchanged:
 		if err := cl.Reconcile(rel); err != nil {
 			meta.SetStatusCondition(&bi.Status.Conditions, metav1.Condition{
-				Type:    "Installed",
+				Type:    rukpakv1alpha1.TypeInstalled,
 				Status:  metav1.ConditionFalse,
-				Reason:  "ReconcileFailed",
+				Reason:  rukpakv1alpha1.ReasonReconcileFailed,
 				Message: err.Error(),
 			})
 			return ctrl.Result{}, err
@@ -229,9 +229,9 @@ func (r *BundleInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		uMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 		if err != nil {
 			meta.SetStatusCondition(&bi.Status.Conditions, metav1.Condition{
-				Type:    "Installed",
+				Type:    rukpakv1alpha1.TypeInstalled,
 				Status:  metav1.ConditionFalse,
-				Reason:  "CreateDynamicWatchFailed",
+				Reason:  rukpakv1alpha1.ReasonCreateDynamicWatchFailed,
 				Message: err.Error(),
 			})
 			return ctrl.Result{}, err
@@ -255,18 +255,18 @@ func (r *BundleInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			return nil
 		}(); err != nil {
 			meta.SetStatusCondition(&bi.Status.Conditions, metav1.Condition{
-				Type:    "Installed",
+				Type:    rukpakv1alpha1.TypeInstalled,
 				Status:  metav1.ConditionFalse,
-				Reason:  "CreateDynamicWatchFailed",
+				Reason:  rukpakv1alpha1.ReasonCreateDynamicWatchFailed,
 				Message: err.Error(),
 			})
 			return ctrl.Result{}, err
 		}
 	}
 	meta.SetStatusCondition(&bi.Status.Conditions, metav1.Condition{
-		Type:   "Installed",
+		Type:   rukpakv1alpha1.TypeInstalled,
 		Status: metav1.ConditionTrue,
-		Reason: "InstallationSucceeded",
+		Reason: rukpakv1alpha1.ReasonInstallationSucceeded,
 	})
 	bi.Status.InstalledBundleName = bi.Spec.BundleName
 	return ctrl.Result{}, nil


### PR DESCRIPTION
# Summary
Adding changes that improve the UX around BundleInstances that reference a delete Bundle. Originally, a BundleInstance with an underlying Bundle that was deleted would emit a "BundleLookupFailed" reason for the "Install" condition. Now there is a "HasValidBundle" condition that is emitted on this event and the original "InstallSucceeded" condition along with it.

# Open Questions
Should we have a follow-up PR that adds a printer column to track the state of the "HasValidBundle"?

Closes #129 