### PR TITLE
Serve bundle content tar.gz via http instead of writing pod logs

### DIFF
--- a/cmd/unpack/main.go
+++ b/cmd/unpack/main.go
@@ -1,20 +1,31 @@
 package main
 
 import (
-	"encoding/json"
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"fmt"
+	"io"
 	"io/fs"
 	"log"
+	"net/http"
 	"os"
+	"time"
+
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
+	"github.com/spf13/cobra"
 
 	"github.com/operator-framework/rukpak/internal/version"
-
-	"github.com/spf13/cobra"
 )
 
 func main() {
-	var bundleDir string
-	var rukpakVersion bool
+	var (
+		bundleDir  string
+		listenAddr string
+
+		rukpakVersion bool
+	)
 
 	cmd := &cobra.Command{
 		Use:  "unpack",
@@ -24,36 +35,83 @@ func main() {
 				fmt.Printf("Git commit: %s\n", version.String())
 				os.Exit(0)
 			}
-			bundleFS := os.DirFS(bundleDir)
-			bundleContents := map[string][]byte{}
-			if err := fs.WalkDir(bundleFS, ".", func(path string, d fs.DirEntry, err error) error {
-				if err != nil {
-					return err
-				}
-				if d.IsDir() {
-					return nil
-				}
-				data, err := fs.ReadFile(bundleFS, path)
-				if err != nil {
-					return fmt.Errorf("read file %q: %w", path, err)
-				}
-				bundleContents[path] = data
-				return nil
-			}); err != nil {
-				log.Fatalf("walk bundle dir %q: %v", bundleDir, err)
+			contentHandler := serveBundle(os.DirFS(bundleDir))
+			h := mux.NewRouter()
+			h.Handle("/content", contentHandler).Methods(http.MethodGet)
+			srv := http.Server{
+				Addr:         listenAddr,
+				Handler:      handlers.CombinedLoggingHandler(os.Stdout, h),
+				ReadTimeout:  1 * time.Second,
+				WriteTimeout: 10 * time.Second,
 			}
-
-			encoder := json.NewEncoder(os.Stdout)
-			if err := encoder.Encode(bundleContents); err != nil {
+			if err := srv.ListenAndServe(); err != nil {
 				log.Fatal(err)
 			}
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&bundleDir, "bundle-dir", "", "directory in which the bundle can be found")
+	cmd.Flags().StringVar(&listenAddr, "listen-addr", ":8080", "address on which to host http server")
 	cmd.Flags().BoolVar(&rukpakVersion, "version", false, "displays rukpak version information")
 
 	if err := cmd.Execute(); err != nil {
 		log.Fatal(err)
+	}
+}
+
+func serveBundle(bundle fs.FS) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		buf := &bytes.Buffer{}
+		gzw := gzip.NewWriter(buf)
+		tw := tar.NewWriter(gzw)
+		if err := fs.WalkDir(bundle, ".", func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if d.Type()&os.ModeSymlink != 0 {
+				return nil
+			}
+
+			info, err := d.Info()
+			if err != nil {
+				return fmt.Errorf("get file info for %q: %w", path, err)
+			}
+
+			h, err := tar.FileInfoHeader(info, "")
+			if err != nil {
+				return fmt.Errorf("build tar file info header for %q: %w", path, err)
+			}
+			h.Uid = 0
+			h.Gid = 0
+			h.Uname = ""
+			h.Gname = ""
+			h.Name = path
+
+			if err := tw.WriteHeader(h); err != nil {
+				return fmt.Errorf("write tar header for %q: %w", path, err)
+			}
+			if !d.IsDir() {
+				data, err := fs.ReadFile(bundle, path)
+				if err != nil {
+					return fmt.Errorf("read file %q: %w", path, err)
+				}
+				if _, err := tw.Write(data); err != nil {
+					return fmt.Errorf("write tar data for %q: %w", path, err)
+				}
+			}
+			return nil
+		}); err != nil {
+			http.Error(writer, err.Error(), http.StatusInternalServerError)
+		}
+		if err := tw.Close(); err != nil {
+			http.Error(writer, err.Error(), http.StatusInternalServerError)
+		}
+		if err := gzw.Close(); err != nil {
+			http.Error(writer, err.Error(), http.StatusInternalServerError)
+		}
+		if _, err := io.Copy(writer, buf); err != nil {
+			http.Error(writer, err.Error(), http.StatusInternalServerError)
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,9 @@ go 1.17
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-logr/logr v1.2.0
+	github.com/gorilla/handlers v1.5.1
+	github.com/gorilla/mux v1.8.0
+	github.com/nlepage/go-tarfs v1.0.6
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
 	github.com/operator-framework/api v0.13.0
@@ -50,6 +53,7 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/color v1.13.0 // indirect
+	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-logr/zapr v1.2.0 // indirect
@@ -66,7 +70,6 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
-	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1024,6 +1024,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
+github.com/nlepage/go-tarfs v1.0.6 h1:BlHLlAUo9AR+PG4aBHK2Abbf2qtJiP79nZR8jLbtZ4w=
+github.com/nlepage/go-tarfs v1.0.6/go.mod h1:guZJ15k0DRG0niLSTgPAJOI/fc006UU+qcpS0AS21Pg=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/internal/provisioner/plain/controllers/bundle_controller.go
+++ b/internal/provisioner/plain/controllers/bundle_controller.go
@@ -18,16 +18,17 @@ package controllers
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
 	"path/filepath"
 	"strings"
-	"testing/fstest"
 
+	"github.com/nlepage/go-tarfs"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -44,10 +45,11 @@ import (
 	"github.com/operator-framework/rukpak/internal/storage"
 	"github.com/operator-framework/rukpak/internal/updater"
 	"github.com/operator-framework/rukpak/internal/util"
+	"github.com/operator-framework/rukpak/internal/version"
 )
 
 const (
-	bundleUnpackContainerName  = "bundle"
+	bundleContainerName        = "bundle"
 	plainBundleProvisionerName = "plain"
 )
 
@@ -57,6 +59,8 @@ type BundleReconciler struct {
 	KubeClient kubernetes.Interface
 	Scheme     *runtime.Scheme
 	Storage    storage.Storage
+
+	HTTPClient *http.Client
 
 	PodNamespace    string
 	UnpackImage     string
@@ -109,12 +113,9 @@ func (r *BundleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ c
 		r.handlePendingPod(&u, pod)
 		return ctrl.Result{}, nil
 	case corev1.PodRunning:
-		r.handleRunningPod(&u)
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, r.handleRunningPod(ctx, &u, bundle, pod)
 	case corev1.PodFailed:
 		return ctrl.Result{}, r.handleFailedPod(ctx, &u, pod)
-	case corev1.PodSucceeded:
-		return ctrl.Result{}, r.handleCompletedPod(ctx, &u, bundle, pod)
 	default:
 		return ctrl.Result{}, r.handleUnexpectedPod(ctx, &u, pod)
 	}
@@ -145,19 +146,6 @@ func (r *BundleReconciler) handlePendingPod(u *updater.Updater, pod *corev1.Pod)
 			Status:  metav1.ConditionFalse,
 			Reason:  rukpakv1alpha1.ReasonUnpackPending,
 			Message: strings.Join(messages, "; "),
-		}),
-	)
-}
-
-func (r *BundleReconciler) handleRunningPod(u *updater.Updater) {
-	u.UpdateStatus(
-		updater.SetBundleInfo(nil),
-		updater.EnsureBundleDigest(""),
-		updater.SetPhase(rukpakv1alpha1.PhaseUnpacking),
-		updater.EnsureCondition(metav1.Condition{
-			Type:   rukpakv1alpha1.TypeUnpacked,
-			Status: metav1.ConditionFalse,
-			Reason: rukpakv1alpha1.ReasonUnpacking,
 		}),
 	)
 }
@@ -207,9 +195,6 @@ func (r *BundleReconciler) ensureUnpackPod(ctx context.Context, bundle *rukpakv1
 		})
 		pod.SetOwnerReferences([]metav1.OwnerReference{*controllerRef})
 		pod.Spec.AutomountServiceAccountToken = &automountServiceAccountToken
-		pod.Spec.Volumes = []corev1.Volume{
-			{Name: "util", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
-		}
 		pod.Spec.RestartPolicy = corev1.RestartPolicyNever
 		if len(pod.Spec.InitContainers) != 1 {
 			pod.Spec.InitContainers = make([]corev1.Container, 1)
@@ -223,11 +208,17 @@ func (r *BundleReconciler) ensureUnpackPod(ctx context.Context, bundle *rukpakv1
 		if len(pod.Spec.Containers) != 1 {
 			pod.Spec.Containers = make([]corev1.Container, 1)
 		}
-		pod.Spec.Containers[0].Name = bundleUnpackContainerName
+		pod.Spec.Containers[0].Name = bundleContainerName
 		pod.Spec.Containers[0].Image = bundle.Spec.Image
 		pod.Spec.Containers[0].ImagePullPolicy = corev1.PullAlways
-		pod.Spec.Containers[0].Command = []string{"/util/unpack", "--bundle-dir", "/manifests"}
+		pod.Spec.Containers[0].Command = []string{"/util/unpack", "--bundle-dir=/manifests", "--listen-addr=:8080"}
 		pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{Name: "util", MountPath: "/util"}}
+
+		if len(pod.Spec.Volumes) != 1 {
+			pod.Spec.Volumes = make([]corev1.Volume, 1)
+		}
+
+		pod.Spec.Volumes[0] = corev1.Volume{Name: "util", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}
 		return nil
 	})
 }
@@ -258,7 +249,7 @@ func updateStatusUnpackFailing(u *updater.Updater, err error) error {
 	return err
 }
 
-func (r *BundleReconciler) handleCompletedPod(ctx context.Context, u *updater.Updater, bundle *rukpakv1alpha1.Bundle, pod *corev1.Pod) error {
+func (r *BundleReconciler) handleRunningPod(ctx context.Context, u *updater.Updater, bundle *rukpakv1alpha1.Bundle, pod *corev1.Pod) error {
 	bundleFS, err := r.getBundleContents(ctx, pod)
 	if err != nil {
 		return updateStatusUnpackFailing(u, fmt.Errorf("get bundle contents: %w", err))
@@ -305,20 +296,25 @@ func (r *BundleReconciler) handleCompletedPod(ctx context.Context, u *updater.Up
 }
 
 func (r *BundleReconciler) getBundleContents(ctx context.Context, pod *corev1.Pod) (fs.FS, error) {
-	bundleContentsData, err := r.getPodLogs(ctx, pod)
+	url := fmt.Sprintf("http://%s:8080/content", pod.Status.PodIP)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("get bundle contents: %w", err)
+		return nil, fmt.Errorf("create get request for %q: %v", url, pod)
 	}
-	decoder := json.NewDecoder(bytes.NewReader(bundleContentsData))
-	bundleContents := map[string][]byte{}
-	if err := decoder.Decode(&bundleContents); err != nil {
-		return nil, err
+	req.Header.Set("User-Agent", fmt.Sprintf("%s_%s/%s", rukpakv1alpha1.GroupVersion.Group, plainBundleProvisionerName, version.String()))
+	resp, err := r.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http get %q: %w", url, err)
 	}
-	bundleFS := fstest.MapFS{}
-	for name, data := range bundleContents {
-		bundleFS[name] = &fstest.MapFile{Data: data}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("http get %q: unexpected response status: %s", url, resp.Status)
 	}
-	return bundleFS, nil
+	gzr, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read gzip response from %q: %w", url, err)
+	}
+	return tarfs.New(gzr)
 }
 
 func (r *BundleReconciler) getPodLogs(ctx context.Context, pod *corev1.Pod) ([]byte, error) {
@@ -336,7 +332,7 @@ func (r *BundleReconciler) getPodLogs(ctx context.Context, pod *corev1.Pod) ([]b
 
 func (r *BundleReconciler) getBundleImageDigest(pod *corev1.Pod) (string, error) {
 	for _, ps := range pod.Status.ContainerStatuses {
-		if ps.Name == bundleUnpackContainerName && ps.ImageID != "" {
+		if ps.Name == bundleContainerName && ps.ImageID != "" {
 			return ps.ImageID, nil
 		}
 	}
@@ -378,6 +374,10 @@ func getObjects(bundleFS fs.FS) ([]client.Object, error) {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *BundleReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.HTTPClient == nil {
+		r.HTTPClient = http.DefaultClient
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&rukpakv1alpha1.Bundle{}, builder.WithPredicates(
 			util.BundleProvisionerFilter(plainBundleProvisionerID),

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,6 +21,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 )
 
 func BundleProvisionerFilter(provisionerClassName string) predicate.Predicate {


### PR DESCRIPTION
Closes #153 

This PR changes the unpack binary to serve the bundle directory as a tar.gz file on the `/content` endpoint. It also updates the bundle controller for the plain provisioner to read the bundle content via this new endpoint instead of fetching the pod logs.