### PR TITLE
serve bundle tar.gz via http instead of writing pod logs

### DIFF
--- a/cmd/unpack/main.go
+++ b/cmd/unpack/main.go
@@ -1,20 +1,35 @@
 package main
 
 import (
-	"encoding/json"
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log"
+	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
+	"github.com/spf13/cobra"
 
 	"github.com/operator-framework/rukpak/internal/version"
-
-	"github.com/spf13/cobra"
 )
 
 func main() {
-	var bundleDir string
-	var rukpakVersion bool
+	var (
+		bundleDir  string
+		listenAddr string
+
+		rukpakVersion bool
+	)
 
 	cmd := &cobra.Command{
 		Use:  "unpack",
@@ -24,36 +39,99 @@ func main() {
 				fmt.Printf("Git commit: %s\n", version.String())
 				os.Exit(0)
 			}
-			bundleFS := os.DirFS(bundleDir)
-			bundleContents := map[string][]byte{}
-			if err := fs.WalkDir(bundleFS, ".", func(path string, d fs.DirEntry, err error) error {
-				if err != nil {
-					return err
-				}
-				if d.IsDir() {
-					return nil
-				}
-				data, err := fs.ReadFile(bundleFS, path)
-				if err != nil {
-					return fmt.Errorf("read file %q: %w", path, err)
-				}
-				bundleContents[path] = data
-				return nil
-			}); err != nil {
-				log.Fatalf("walk bundle dir %q: %v", bundleDir, err)
+			contentHandler := serveBundle(os.DirFS(bundleDir))
+			h := mux.NewRouter()
+			h.Handle("/content", contentHandler).Methods(http.MethodGet)
+			srv := http.Server{
+				Addr:         listenAddr,
+				Handler:      handlers.CombinedLoggingHandler(os.Stdout, h),
+				ReadTimeout:  1 * time.Second,
+				WriteTimeout: 10 * time.Second,
 			}
+			go func() {
+				log.Println("listening on", srv.Addr)
+				if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+					log.Fatal(err)
+				}
+			}()
 
-			encoder := json.NewEncoder(os.Stdout)
-			if err := encoder.Encode(bundleContents); err != nil {
+			ctx, cancel := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+			defer cancel()
+			<-ctx.Done()
+
+			shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancelShutdown()
+			log.Println("shutting down")
+			if err := srv.Shutdown(shutdownCtx); err != nil {
 				log.Fatal(err)
 			}
+			log.Println("shutdown complete")
+
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&bundleDir, "bundle-dir", "", "directory in which the bundle can be found")
+	cmd.Flags().StringVar(&listenAddr, "listen-addr", ":8080", "listen address for http server")
 	cmd.Flags().BoolVar(&rukpakVersion, "version", false, "displays rukpak version information")
 
 	if err := cmd.Execute(); err != nil {
 		log.Fatal(err)
+	}
+}
+
+func serveBundle(bundle fs.FS) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		buf := &bytes.Buffer{}
+		gzw := gzip.NewWriter(buf)
+		tw := tar.NewWriter(gzw)
+		if err := fs.WalkDir(bundle, ".", func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if d.Type()&os.ModeSymlink != 0 {
+				return nil
+			}
+
+			info, err := d.Info()
+			if err != nil {
+				return fmt.Errorf("get file info for %q: %w", path, err)
+			}
+
+			h, err := tar.FileInfoHeader(info, "")
+			if err != nil {
+				return fmt.Errorf("build tar file info header for %q: %w", path, err)
+			}
+			h.Uid = 0
+			h.Gid = 0
+			h.Uname = ""
+			h.Gname = ""
+			h.Name = path
+
+			if err := tw.WriteHeader(h); err != nil {
+				return fmt.Errorf("write tar header for %q: %w", path, err)
+			}
+			if !d.IsDir() {
+				data, err := fs.ReadFile(bundle, path)
+				if err != nil {
+					return fmt.Errorf("read file %q: %w", path, err)
+				}
+				if _, err := tw.Write(data); err != nil {
+					return fmt.Errorf("write tar data for %q: %w", path, err)
+				}
+			}
+			return nil
+		}); err != nil {
+			http.Error(writer, err.Error(), http.StatusInternalServerError)
+		}
+		if err := tw.Close(); err != nil {
+			http.Error(writer, err.Error(), http.StatusInternalServerError)
+		}
+		if err := gzw.Close(); err != nil {
+			http.Error(writer, err.Error(), http.StatusInternalServerError)
+		}
+		if _, err := io.Copy(writer, buf); err != nil {
+			http.Error(writer, err.Error(), http.StatusInternalServerError)
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,9 @@ go 1.17
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-logr/logr v1.2.0
+	github.com/gorilla/handlers v1.5.1
+	github.com/gorilla/mux v1.8.0
+	github.com/nlepage/go-tarfs v1.0.6
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
 	github.com/operator-framework/api v0.13.0
@@ -50,6 +53,7 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/color v1.13.0 // indirect
+	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-logr/zapr v1.2.0 // indirect
@@ -66,7 +70,6 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
-	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1024,6 +1024,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
+github.com/nlepage/go-tarfs v1.0.6 h1:BlHLlAUo9AR+PG4aBHK2Abbf2qtJiP79nZR8jLbtZ4w=
+github.com/nlepage/go-tarfs v1.0.6/go.mod h1:guZJ15k0DRG0niLSTgPAJOI/fc006UU+qcpS0AS21Pg=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,6 +21,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 )
 
 func BundleProvisionerFilter(provisionerClassName string) predicate.Predicate {


### PR DESCRIPTION
Retrying #154 here (that one seemed to succumb to today's GitHub problems)

Closes https://github.com/operator-framework/rukpak/issues/153

This PR changes the unpack binary to serve the bundle directory as a tar.gz file on the /content endpoint. It also updates the bundle controller for the plain provisioner to read the bundle content via this new endpoint instead of fetching the pod logs.