### PR TITLE
WIP: Proof of concept to delete unpack pods, immutable bundles, and deny configmap deletes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,8 @@
-FROM golang:1.17-buster AS builder
-
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-COPY Makefile Makefile
-COPY cmd cmd
-COPY api api
-COPY internal internal
-# copy git-related information for binary version information
-COPY .git/HEAD .git/HEAD
-COPY .git/refs/heads/. .git/refs/heads
-RUN mkdir -p .git/objects
-
-RUN make build
-
 FROM gcr.io/distroless/static:debug
 
 WORKDIR /
-COPY --from=builder /workspace/bin/plain .
-COPY --from=builder /workspace/bin/unpack .
+COPY bin/plain-linux plain
+COPY bin/unpack-linux unpack
 EXPOSE 8080
 
 ENTRYPOINT ["/plain"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,9 +1,0 @@
-FROM gcr.io/distroless/static:debug
-
-WORKDIR /
-COPY bin/plain-linux plain
-COPY bin/unpack-linux unpack
-EXPOSE 8080
-
-ENTRYPOINT ["/plain"]
-CMD ["run"]

--- a/api/v1alpha1/bundle_types.go
+++ b/api/v1alpha1/bundle_types.go
@@ -29,6 +29,7 @@ const (
 	ReasonUnpacking        = "Unpacking"
 	ReasonUnpackSuccessful = "UnpackSuccessful"
 	ReasonUnpackFailed     = "UnpackFailed"
+	ReasonLoadFailed       = "LoadFailed"
 
 	PhasePending   = "Pending"
 	PhaseUnpacking = "Unpacking"

--- a/internal/provisioner/plain/manifests/06_webhook.yaml
+++ b/internal/provisioner/plain/manifests/06_webhook.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rukpak-webhook
+  namespace: rukpak-system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    app: plain-provisioner
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: rukpak-webhook
+  annotations:
+    cert-manager.io/inject-ca-from: rukpak-system/rukpak-webhook-certificate
+webhooks:
+  - name: bundles.core.rukpak.io
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: rukpak-webhook
+        namespace: rukpak-system
+        path: /validate-core-rukpak-io-v1alpha1-bundle
+        port: 443
+    failurePolicy: Fail
+    rules:
+      - apiGroups:
+          - core.rukpak.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - UPDATE
+        resources:
+          - bundles
+          - bundles/status
+    sideEffects: None
+  - name: configmaps.plain.core.rukpak.io
+    admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: rukpak-webhook
+        namespace: rukpak-system
+        path: /validate-core-v1-configmap
+        port: 443
+    failurePolicy: Fail
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - UPDATE
+          - DELETE
+        resources:
+          - configmaps
+    sideEffects: None
+    objectSelector:
+      matchLabels:
+        core.rukpak.io/owner-kind: Bundle
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: rukpak-system
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: rukpak-webhook-certificate
+  namespace: rukpak-system
+spec:
+  secretName: rukpak-webhook-certificate
+  dnsNames:
+    - rukpak-webhook.rukpak-system.svc
+  issuerRef:
+    name: selfsigned
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned
+  namespace: rukpak-system
+spec:
+  selfSigned: {}

--- a/internal/provisioner/plain/manifests/07_deployment.yaml
+++ b/internal/provisioner/plain/manifests/07_deployment.yaml
@@ -22,3 +22,17 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
+              name: metrics
+              protocol: TCP
+            - containerPort: 9443
+              name: webhooks
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: rukpak-webhook-certificate

--- a/internal/provisioner/plain/webhooks/bundles.go
+++ b/internal/provisioner/plain/webhooks/bundles.go
@@ -1,0 +1,43 @@
+package webhooks
+
+import (
+	"context"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+)
+
+func NewValidatingBundleWebhook(mgr manager.Manager) (*webhook.Admission, error) {
+	decoder, err := admission.NewDecoder(mgr.GetScheme())
+	if err != nil {
+		return nil, err
+	}
+	return &webhook.Admission{
+		Handler: admission.HandlerFunc(func(ctx context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
+			switch req.Operation {
+			case admissionv1.Update:
+				oldBundle := &rukpakv1alpha1.Bundle{}
+				if err := decoder.DecodeRaw(req.OldObject, oldBundle); err != nil {
+					return webhook.Denied(err.Error())
+				}
+				newBundle := &rukpakv1alpha1.Bundle{}
+				if err := decoder.DecodeRaw(req.Object, newBundle); err != nil {
+					return webhook.Denied(err.Error())
+				}
+				if !equality.Semantic.DeepEqual(oldBundle.Spec, newBundle.Spec) {
+					return webhook.Denied("bundle.spec is immutable")
+				}
+				if oldBundle.Status.Phase == rukpakv1alpha1.PhaseUnpacked && !equality.Semantic.DeepEqual(oldBundle.Status, newBundle.Status) {
+					return webhook.Denied("bundle.status is immutable when bundle.status.phase==Unpacked")
+				}
+				return webhook.Allowed("")
+			}
+			return webhook.Allowed("")
+		}),
+	}, nil
+}

--- a/internal/provisioner/plain/webhooks/configmaps.go
+++ b/internal/provisioner/plain/webhooks/configmaps.go
@@ -1,0 +1,78 @@
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+)
+
+func NewValidatingConfigMapWebhook(mgr manager.Manager) (*webhook.Admission, error) {
+	cl := mgr.GetClient()
+	decoder, err := admission.NewDecoder(mgr.GetScheme())
+	if err != nil {
+		return nil, err
+	}
+	return &webhook.Admission{
+		Handler: admission.HandlerFunc(func(ctx context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
+			switch req.Operation {
+			case admissionv1.Update:
+				oldCm := &corev1.ConfigMap{}
+				if err := decoder.DecodeRaw(req.OldObject, oldCm); err != nil {
+					return webhook.Denied(err.Error())
+				}
+				newCm := &corev1.ConfigMap{}
+				if err := decoder.DecodeRaw(req.Object, newCm); err != nil {
+					return webhook.Denied(err.Error())
+				}
+				oldCmLabels := keys(oldCm.Labels)
+				newCmLabels := keys(newCm.Labels)
+				dropped := oldCmLabels.Difference(newCmLabels)
+
+				labels := []string{}
+				for _, l := range dropped.List() {
+					if strings.HasPrefix(l, "core.rukpak.io/") {
+						labels = append(labels, l)
+					}
+				}
+				if len(labels) > 0 {
+					return webhook.Denied(fmt.Errorf("cannot delete labels %s", labels).Error())
+				}
+				return webhook.Allowed("")
+			case admissionv1.Delete:
+				cm := &corev1.ConfigMap{}
+				if err := cl.Get(ctx, types.NamespacedName{Name: req.Name, Namespace: req.Namespace}, cm); err != nil {
+					return webhook.Denied(err.Error())
+				}
+				bundleName := cm.Labels["core.rukpak.io/owner-name"]
+				bundle := &rukpakv1alpha1.Bundle{}
+				err := cl.Get(ctx, types.NamespacedName{Name: bundleName}, bundle)
+				if err == nil {
+					return webhook.Denied(fmt.Sprintf("deletion denied when %s %q still exists", bundle.GroupVersionKind(), bundle.Name))
+				}
+				if !apierrors.IsNotFound(err) {
+					return webhook.Denied(err.Error())
+				}
+			}
+			return webhook.Allowed("")
+		}),
+	}, nil
+}
+
+func keys(m map[string]string) sets.String {
+	s := sets.NewString()
+	for k := range m {
+		s.Insert(k)
+	}
+	return s
+}


### PR DESCRIPTION
This PR clears completed pods after bundle contents are stored to configmaps

It also adds two webhooks:
1. Bundles: Spec is immutable, Status is immutable once Unpacked phase is reached
2. Configmaps:
    - Any configmap in the rukpak-system namespace with a
      core.rukpak.io/owner-kind==Bundle label cannot be deleted if its
      owning Bundle exists.
    - Any configmap in the rukpak-system namespace with a
      core.rukpak.io/owner-kind==Bundle label cannot have any of its
      core.rukpak.io labels removed.