### PR TITLE
make bundlespec and bundleinstancespec required

### DIFF
--- a/api/v1alpha1/bundle_types.go
+++ b/api/v1alpha1/bundle_types.go
@@ -83,7 +83,7 @@ type Bundle struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   BundleSpec   `json:"spec,omitempty"`
+	Spec   BundleSpec   `json:"spec"`
 	Status BundleStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha1/bundleinstance_types.go
+++ b/api/v1alpha1/bundleinstance_types.go
@@ -71,7 +71,7 @@ type BundleInstance struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   BundleInstanceSpec   `json:"spec,omitempty"`
+	Spec   BundleInstanceSpec   `json:"spec"`
 	Status BundleInstanceStatus `json:"status,omitempty"`
 }
 

--- a/manifests/core.rukpak.io_bundleinstances.yaml
+++ b/manifests/core.rukpak.io_bundleinstances.yaml
@@ -32,6 +32,8 @@ spec:
         openAPIV3Schema:
           description: BundleInstance is the Schema for the bundleinstances API
           type: object
+          required:
+            - spec
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/manifests/core.rukpak.io_bundles.yaml
+++ b/manifests/core.rukpak.io_bundles.yaml
@@ -29,6 +29,8 @@ spec:
         openAPIV3Schema:
           description: Bundle is the Schema for the bundles API
           type: object
+          required:
+            - spec
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'


### PR DESCRIPTION
Signed-off-by: akihikokuroda <akuroda@us.ibm.com>

I believe the **BundleSpec** and **BundleInstanceSpec** should be required.