### PR TITLE
add unpacked object length check 

### DIFF
--- a/internal/provisioner/plain/controllers/bundle_controller.go
+++ b/internal/provisioner/plain/controllers/bundle_controller.go
@@ -273,6 +273,10 @@ func (r *BundleReconciler) handleCompletedPod(ctx context.Context, u *updater.Up
 	if err != nil {
 		return updateStatusUnpackFailing(u, fmt.Errorf("get objects from bundle manifests: %w", err))
 	}
+	if len(objects) == 0 {
+		return updateStatusUnpackFailing(u, errors.New("invalid bundle: found zero objects: "+
+			"plain+v0 bundles are required to contain at least one object"))
+	}
 
 	if err := r.Storage.Store(ctx, bundle, objects); err != nil {
 		return updateStatusUnpackFailing(u, fmt.Errorf("persist bundle objects: %w", err))


### PR DESCRIPTION
This check ensures that in the case where no objects where unpacked as a result of the unpack pod a failure status will propagate to the Bundle. 

This prevents the case where zero objects are stored successfully and the Bundle is considered Unpacked even though no content was persisted to the cluster. 