### PR TITLE
plain: Infer the ImagePullPolicy from the Bundle's spec.Image tag

### DIFF
--- a/internal/provisioner/plain/controllers/bundle_controller.go
+++ b/internal/provisioner/plain/controllers/bundle_controller.go
@@ -222,7 +222,6 @@ func (r *BundleReconciler) ensureUnpackPod(ctx context.Context, bundle *rukpakv1
 		if bundle.Spec.Source.Image != nil {
 			pod.Spec.Containers[0].Name = bundleUnpackContainerName
 			pod.Spec.Containers[0].Image = bundle.Spec.Source.Image.Ref
-			pod.Spec.Containers[0].ImagePullPolicy = corev1.PullAlways
 			pod.Spec.Containers[0].Command = []string{"/util/unpack", "--bundle-dir", "/manifests"}
 			pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{Name: "util", MountPath: "/util"}}
 		}


### PR DESCRIPTION
The default image pull policy is IfNotPresent for a container image unless the container image tag is set to 'latest' or the tag is unset (e.g. ""), so we should infer the pull policy from the user-provided container image.