### PR TITLE
make unpack ignore irrelevant root directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,10 @@ build-local-container: build ## Builds the provisioner container image using loc
 
 kind-load-bundles:
 	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/valid -t testdata/bundles/plain-v0:valid
+	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/empty -t testdata/bundles/plain-v0:empty
 	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/invalid-crds-and-crs -t testdata/bundles/plain-v0:invalid-crds-and-crs
 	${KIND} load docker-image testdata/bundles/plain-v0:valid --name $(KIND_CLUSTER_NAME)
+	${KIND} load docker-image testdata/bundles/plain-v0:empty --name $(KIND_CLUSTER_NAME)
 	${KIND} load docker-image testdata/bundles/plain-v0:invalid-crds-and-crs --name $(KIND_CLUSTER_NAME)
 
 kind-load: ## Load-image loads the currently constructed image onto the cluster

--- a/internal/provisioner/plain/controllers/bundle_controller.go
+++ b/internal/provisioner/plain/controllers/bundle_controller.go
@@ -222,8 +222,8 @@ func (r *BundleReconciler) ensureUnpackPod(ctx context.Context, bundle *rukpakv1
 		if bundle.Spec.Source.Image != nil {
 			pod.Spec.Containers[0].Name = bundleUnpackContainerName
 			pod.Spec.Containers[0].Image = bundle.Spec.Source.Image.Ref
-			pod.Spec.Containers[0].Command = []string{"/util/unpack", "--bundle-dir", "/manifests"}
-			pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{Name: "util", MountPath: "/util"}}
+			pod.Spec.Containers[0].Command = []string{"/bin/unpack", "--bundle-dir", "/"}
+			pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{Name: "util", MountPath: "/bin"}}
 		}
 		return nil
 	})
@@ -346,7 +346,7 @@ func (r *BundleReconciler) getBundleImageDigest(pod *corev1.Pod) (string, error)
 
 func getObjects(bundleFS fs.FS) ([]client.Object, error) {
 	var objects []client.Object
-	const manifestsDir = "."
+	const manifestsDir = "manifests"
 
 	entries, err := fs.ReadDir(bundleFS, manifestsDir)
 	if err != nil {

--- a/testdata/bundles/plain-v0/empty/Dockerfile
+++ b/testdata/bundles/plain-v0/empty/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY emptyfile emptyfile


### PR DESCRIPTION
With this change, we can now unpack the image at the root of the image
filesystem, making unpack capable of handling future bundle formats that
may include other files and directories outside of /manifests

This PR also adds a test to ensure that we correctly fail bundles that
contain no manifests