### PR TITLE
Add focus flag to e2e test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,9 @@ UNIT_TEST_DIRS=$(shell go list ./... | grep -v /test/)
 test-unit: setup-envtest ## Run the unit tests
 	eval $$($(SETUP_ENVTEST) use -p env $(ENVTEST_VERSION)) && go test -count=1 -short $(UNIT_TEST_DIRS)
 
+FOCUS := $(if $(TEST),-focus "$(TEST)")
 test-e2e: ginkgo ## Run the e2e tests
-	$(GINKGO) -v -trace -progress test/e2e
+	$(GINKGO) -v -trace -progress $(FOCUS) test/e2e
 
 ###################
 # Install and Run #


### PR DESCRIPTION
This PR adds a `TEST` variable that allows to easily focus on a specific e2e case. 

```
$ TEST='a valid Bundle referencing a remote container image is created' make test-e2e
cd hack/tools; go build -tags=tools -o bin/ginkgo github.com/onsi/ginkgo/v2/ginkgo
/Users/dsover/code/src/rukpak/hack/tools/bin/ginkgo -v -trace -progress -focus "a valid Bundle referencing a remote container image is created" test/e2e
```