### PR TITLE
Add a new test-e2e-local target 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,8 @@ test-unit: setup-envtest ## Run the unit tests
 test-e2e: ginkgo ## Run the e2e tests
 	$(GINKGO) -v -trace -progress test/e2e
 
+test-e2e-local: kind-cluster run kind-load-bundles test-e2e ## Deploys rukpak onto a new local cluster and runs e2e tests
+
 ###################
 # Install and Run #
 ###################


### PR DESCRIPTION
Adds a new makefile target that that builds binaries locally, deploys rukpak, and then runs the e2e suite. This target is helpful for local testing, because the existing e2e target builds the binaries in a container and takes several minutes to just get started. 