### PR TITLE
make sure nested manifest directories don't cause any affects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,12 +145,14 @@ kind-load-bundles: ## Load the e2e testdata container images into a kind cluster
 	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/empty -t testdata/bundles/plain-v0:empty
 	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/no-manifests -t testdata/bundles/plain-v0:no-manifests
 	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/invalid-crds-and-crs -t testdata/bundles/plain-v0:invalid-crds-and-crs
+	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/subdir -t testdata/bundles/plain-v0:subdir
 	${KIND} load docker-image testdata/bundles/plain-v0:valid --name $(KIND_CLUSTER_NAME)
 	${KIND} load docker-image testdata/bundles/plain-v0:dependent --name $(KIND_CLUSTER_NAME)
 	${KIND} load docker-image testdata/bundles/plain-v0:provides --name $(KIND_CLUSTER_NAME)
 	${KIND} load docker-image testdata/bundles/plain-v0:empty --name $(KIND_CLUSTER_NAME)
 	${KIND} load docker-image testdata/bundles/plain-v0:no-manifests --name $(KIND_CLUSTER_NAME)
 	${KIND} load docker-image testdata/bundles/plain-v0:invalid-crds-and-crs --name $(KIND_CLUSTER_NAME)
+	${KIND} load docker-image testdata/bundles/plain-v0:subdir --name $(KIND_CLUSTER_NAME)
 
 kind-load: ## Load-image loads the currently constructed image onto the cluster
 	${KIND} load docker-image $(IMAGE) --name $(KIND_CLUSTER_NAME)

--- a/internal/provisioner/plain/controllers/bundle_controller.go
+++ b/internal/provisioner/plain/controllers/bundle_controller.go
@@ -359,7 +359,7 @@ func getObjects(bundleFS fs.FS) ([]client.Object, error) {
 	}
 	for _, e := range entries {
 		if e.IsDir() {
-			continue
+			return nil, fmt.Errorf("subdirectories are not allowed within the %q directory of the bundle image filesystem: found %q", manifestsDir, filepath.Join(manifestsDir, e.Name()))
 		}
 		fileData, err := fs.ReadFile(bundleFS, filepath.Join(manifestsDir, e.Name()))
 		if err != nil {

--- a/testdata/bundles/plain-v0/subdir/.dockerignore
+++ b/testdata/bundles/plain-v0/subdir/.dockerignore
@@ -1,0 +1,1 @@
+manifests/.gitignore

--- a/testdata/bundles/plain-v0/subdir/Dockerfile
+++ b/testdata/bundles/plain-v0/subdir/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY manifests /manifests

--- a/testdata/bundles/plain-v0/subdir/manifests/emptydir/.gitignore
+++ b/testdata/bundles/plain-v0/subdir/manifests/emptydir/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/testdata/bundles/plain-v0/subdir/manifests/namespace-a.yaml
+++ b/testdata/bundles/plain-v0/subdir/manifests/namespace-a.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace-a

--- a/testdata/bundles/plain-v0/subdir/manifests/subdir/namespace-b.yaml
+++ b/testdata/bundles/plain-v0/subdir/manifests/subdir/namespace-b.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace-b


### PR DESCRIPTION
Signed-off-by: akihikokuroda <akuroda@us.ibm.com>

Add a new bundle that has subdirectories in the manifests directory.  The yaml files in the subdirectory should be ignored.

Closes #195 