### PR TITLE
[WIP] feat(bundleinstance): add call to crd validator inside of controller

### DIFF
--- a/api/v1alpha1/bundleinstance_types.go
+++ b/api/v1alpha1/bundleinstance_types.go
@@ -20,9 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 const (
 	TypeHasValidBundle       = "HasValidBundle"
 	TypeInvalidBundleContent = "InvalidBundleContent"
@@ -38,6 +35,7 @@ const (
 	ReasonReconcileFailed          = "ReconcileFailed"
 	ReasonCreateDynamicWatchFailed = "CreateDynamicWatchFailed"
 	ReasonInstallationSucceeded    = "InstallationSucceeded"
+	ReasonUnsafeCRDUpgrade         = "UnsafeCRDUpgrade"
 )
 
 // BundleInstanceSpec defines the desired state of BundleInstance


### PR DESCRIPTION
## Summary
Doing a few things here that we should talk through:

1. Moving the `crd` package into its own separate one. Additionally remove its ability to execute a creation/upgrade.
2. Calling the `crd`.`Validate()` function on any incoming CRD's to ensure the upgrade won't cause any destructive actions.
3. Added a new `ReasonUnsafeCRDUpgrade` status that gets created on failure to `Validate` the `crd`

## Working On
This is not complete yet, there are still a few things I'm working through but wanted to get the approach into code review while working through theses:

1. Adding a label/annotation/spec field that turns this functionality off
2. Adding a few E2E test cases for this logic