### PR TITLE
Makefile: Include cert-manager installation on `install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test-e2e: ginkgo ## Run the e2e tests
 
 ##@ install/run:
 
-install-apis: generate ## Install the core rukpak CRDs
+install-apis: cert-mgr generate ## Install the core rukpak CRDs
 	kubectl apply -f manifests
 	kubectl apply -f manifests/bundle-webhook
 


### PR DESCRIPTION
When using the target `install` on a plain kind cluster, I ran into the
following error:

```
validatingwebhookconfiguration.admissionregistration.k8s.io/rukpak-webhook created
unable to recognize "manifests/bundle-webhook/07_webhook.yaml": no matches for kind
"Certificate" in version "cert-manager.io/v1"
unable to recognize "manifests/bundle-webhook/07_webhook.yaml": no matches for kind
"Issuer" in version "cert-manager.io/v1"
```

Looks like the cert-manager needs to be installed on cluster to support PR #156

This PR includes the installation of the cert-manager to the `install` target.