### PR TITLE
action: fix provisioner image tag

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,5 +23,5 @@ jobs:
         with:
           context: .
           push: true
-          tags: quay.io/operator-framework/plain-provisioner:main
+          tags: quay.io/operator-framework/plain-provisioner:latest
 


### PR DESCRIPTION
The deploy github action has been tagging the plain provisioner image
with `main`, whereas all the mainifests refer to the image with a
`latest` tag. This PR changes the target to build and push the plain
provisioner image with a `latest` tag