### PR TITLE
(Makefile): Remove install and deploy Makefile targets

### DIFF
--- a/internal/provisioner/plain/README.md
+++ b/internal/provisioner/plain/README.md
@@ -101,6 +101,10 @@ the `spec.bundleName` field the `plain` provisioner will create the new bundle c
 content. The provisioner also continually reconciles the created content via dynamic watches to ensure that all
 resources referenced by the bundle are present on the cluster.
 
+
+## Running a specific released version of the plain provisioner
+
+See the latest [releases on github](https://github.com/operator-framework/rukpak/releases) for release-specific install instructions.
 ## Running locally
 
 ### Setup
@@ -112,7 +116,7 @@ Once the cluster has been setup, take the following steps:
 
 * Clone the repository via `git clone https://github.com/operator-framework/rukpak`
 * Navigate to the repository via `cd rukpak`
-* Run `make run` to build and deploy the provisioner onto the local cluster.
+* Run `make run-local` to build and deploy the provisioner onto the local cluster.
 
 ### Installing the Combo Operator
 

--- a/internal/provisioner/plain/main.go
+++ b/internal/provisioner/plain/main.go
@@ -53,6 +53,11 @@ func init() {
 	//+kubebuilder:scaffold:scheme
 }
 
+const (
+	defaultProvisionerImage    = "quay.io/operator-framework/plain-provisioner"
+	defaultProvisionerImageTag = "main"
+)
+
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
@@ -64,7 +69,7 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&systemNamespace, "system-namespace", "rukpak-system", "Configures the namespace that gets used to deploy system resources.")
-	flag.StringVar(&unpackImage, "unpack-image", "quay.io/operator-framework/plain-provisioner:latest", "Configures the container image that gets used to unpack Bundle contents.")
+	flag.StringVar(&unpackImage, "unpack-image", defaultProvisionerImage+":"+defaultProvisionerImageTag, "Configures the container image that gets used to unpack Bundle contents.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")

--- a/internal/provisioner/plain/manifests/06_deployment.yaml
+++ b/internal/provisioner/plain/manifests/06_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: plain-provisioner-admin
       containers:
         - name: plain-provisioner
-          image: quay.io/operator-framework/plain-provisioner:latest
+          image: quay.io/operator-framework/plain-provisioner:local
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/manifests/apis/webhooks/06_deployment.yaml
+++ b/manifests/apis/webhooks/06_deployment.yaml
@@ -20,7 +20,7 @@ spec:
         - name: core-webhook
           command: ["/core"]
           args: ["run"]
-          image: quay.io/operator-framework/plain-provisioner:latest
+          image: quay.io/operator-framework/plain-provisioner:local
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
This PR:

1) Uses the `local` tag for building local images that are used in Makefile targets
2) Cleans up Makefile targets by removing the `install` and `deploy` targets, and consolidates it all in the `run-local` target instead(addresses #209).    
 
Signed-off-by: Anik Bhattacharjee <anikbhattacharya93@gmail.com>    