### PR TITLE
git bundle source: avoid copying full contents of unpack container

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	defaultDirectory = "./manifests"
+	defaultDirectory = "./"
 	repositoryName   = "repo"
 )
 
@@ -38,18 +38,18 @@ func (c *checkoutCmd) String() string {
 	}
 
 	if commit != "" {
-		checkoutCommand = fmt.Sprintf("git clone %s %s && cd %s && git checkout %s && cp -r %s/* /manifests",
+		checkoutCommand = fmt.Sprintf("git clone %s %s && cd %s && git checkout %s && rm -r .git && cp -r %s /bundle",
 			repository, repositoryName, repositoryName, commit, directory)
 		return checkoutCommand
 	}
 
 	if tag != "" {
-		checkoutCommand = fmt.Sprintf("git clone --depth 1 --branch %s %s %s && cd %s && git checkout tags/%s && cp -r %s/* /manifests",
+		checkoutCommand = fmt.Sprintf("git clone --depth 1 --branch %s %s %s && cd %s && git checkout tags/%s && rm -r .git && cp -r %s /bundle",
 			tag, repository, repositoryName, repositoryName, tag, directory)
 		return checkoutCommand
 	}
 
-	checkoutCommand = fmt.Sprintf("git clone --depth 1 --branch %s %s %s && cd %s && git checkout %s && cp -r %s/* /manifests",
+	checkoutCommand = fmt.Sprintf("git clone --depth 1 --branch %s %s %s && cd %s && git checkout %s && rm -r .git && cp -r %s /bundle",
 		branch, repository, repositoryName, repositoryName, branch, directory)
 	return checkoutCommand
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -21,9 +21,9 @@ func TestCheckoutCommand(t *testing.T) {
 					Commit: "4567031e158b42263e70a7c63e29f8981a4a6135",
 				},
 			},
-			expected: fmt.Sprintf("git clone %s %s && cd %s && git checkout %s && cp -r %s/* /manifests",
+			expected: fmt.Sprintf("git clone %s %s && cd %s && git checkout %s && rm -r .git && cp -r %s /bundle",
 				"https://github.com/operator-framework/combo", repositoryName, repositoryName, "4567031e158b42263e70a7c63e29f8981a4a6135",
-				"./manifests"),
+				"./"),
 		},
 		{
 			source: rukpakv1alpha1.GitSource{
@@ -32,8 +32,8 @@ func TestCheckoutCommand(t *testing.T) {
 					Tag: "v0.0.1",
 				},
 			},
-			expected: fmt.Sprintf("git clone --depth 1 --branch %s %s %s && cd %s && git checkout tags/%s && cp -r %s/* /manifests",
-				"v0.0.1", "https://github.com/operator-framework/combo", repositoryName, repositoryName, "v0.0.1", "./manifests"),
+			expected: fmt.Sprintf("git clone --depth 1 --branch %s %s %s && cd %s && git checkout tags/%s && rm -r .git && cp -r %s /bundle",
+				"v0.0.1", "https://github.com/operator-framework/combo", repositoryName, repositoryName, "v0.0.1", "./"),
 		},
 		{
 			source: rukpakv1alpha1.GitSource{
@@ -43,7 +43,7 @@ func TestCheckoutCommand(t *testing.T) {
 					Branch: "dev",
 				},
 			},
-			expected: fmt.Sprintf("git clone --depth 1 --branch %s %s %s && cd %s && git checkout %s && cp -r %s/* /manifests",
+			expected: fmt.Sprintf("git clone --depth 1 --branch %s %s %s && cd %s && git checkout %s && rm -r .git && cp -r %s /bundle",
 				"dev", "https://github.com/operator-framework/combo", repositoryName, repositoryName, "dev", "./deploy"),
 		},
 		{


### PR DESCRIPTION
I was debugging the git source flake and I noticed that the log output
for the unpack pod was unexpectedly long. Turns out, the "contents" JSON
included the full filesystem of that container, which includes a few large
binaries. All we actually need is the bundle directory.

This commit resolves this with a few tweaks:
- Change the volume mount from "/manifests" to "/bundle".
- Just before copying, delete the repo's ".git" directory. This avoids
  copying that directory into /bundle when we're treating the entire git
  repository as the bundle.
- Copy the entire specified directory within the git repo into the
  /bundle directory (this results in "/bundle/manifests" for valid
  bundles.
- The unpack binary unpacks the "/bundle" directory rather than "/"

I'm not sure if this is the root cause of the flake we've been seeing,
but this fix _drastically_ decreases the size of the logs produced by
the unpack bundle, so it seems feasible and is a good change to make
regardless.