### PR TITLE
api,manifests: Introduce a 'Type' custom column to the Bundle CRD

### DIFF
--- a/api/v1alpha1/bundle_types.go
+++ b/api/v1alpha1/bundle_types.go
@@ -117,6 +117,7 @@ type BundleObject struct {
 //+kubebuilder:resource:scope=Cluster
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name=Image,type=string,JSONPath=`.spec.source.image.ref`
+//+kubebuilder:printcolumn:name=Type,type=string,JSONPath=`.spec.source.type`
 //+kubebuilder:printcolumn:name=Phase,type=string,JSONPath=`.status.phase`
 //+kubebuilder:printcolumn:name=Age,type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/manifests/core.rukpak.io_bundles.yaml
+++ b/manifests/core.rukpak.io_bundles.yaml
@@ -18,6 +18,9 @@ spec:
         - jsonPath: .spec.source.image.ref
           name: Image
           type: string
+        - jsonPath: .spec.source.type
+          name: Type
+          type: string
         - jsonPath: .status.phase
           name: Phase
           type: string


### PR DESCRIPTION
Purely exploratory right now but this seemed like it was a nice addition in my eyes when managing multiple Bundles locally:

```console
$ k get bundles
NAME           IMAGE                                           TYPE    PHASE       AGE
combo                                                          git     Failing     17m
combo-v0.0.1   quay.io/tflannag/bundle:combo-operator-v0.0.1   image   Unpacking   6s
```

We'll still have the problem around the IMAGE custom column (tracked in #163) but I think we can work around that limitation in parallel.

Signed-off-by: timflannagan <timflannagan@gmail.com>