### PR TITLE
feat(crdvalidator): adding webhook to ensure safety of crd create/upgrades

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,15 @@ builds:
     - amd64
     ldflags:
     - -X {{ .Env.PKG }}.GitCommit={{ .ShortCommit }}
+  - id: crdvalidator
+    main: ./cmd/crdvalidator
+    binary: crdvalidator
+    goos:
+    - linux
+    goarch:
+    - amd64
+    ldflags:
+    - -X {{ .Env.PKG }}.GitCommit={{ .ShortCommit }}
 dockers:
 - image_templates:
   - "{{ .Env.IMAGE_REPO }}:{{ .Tag }}-amd64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /
 COPY plain plain
 COPY unpack unpack
 COPY core core
+COPY crdvalidator crdvalidator
 
 EXPOSE 8080
 ENTRYPOINT ["/plain"]

--- a/cmd/crdvalidator/handlers/crd.go
+++ b/cmd/crdvalidator/handlers/crd.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/go-logr/logr"
+	"github.com/operator-framework/rukpak/internal/crd"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// +kubebuilder:webhook:path=/validate-crd,mutating=false,failurePolicy=fail,groups="",resources=customresourcedefinitions,verbs=create;update,versions=v1,name=crd-validation-webhook.io
+
+// CrdValidator houses a client, decoder and Handle function for ensuring
+// that a CRD create/update request is safe
+type CrdValidator struct {
+	log     logr.Logger
+	client  client.Client
+	decoder *admission.Decoder
+}
+
+func NewCrdValidator(log logr.Logger, client client.Client) CrdValidator {
+	return CrdValidator{
+		log:    log.V(1).WithName("crdhandler"), // Default to non-verbose logs
+		client: client,
+	}
+}
+
+// Handle takes an incoming CRD create/update request and confirms that it is
+// a safe upgrade based on the crd.Validate() function call
+func (cv *CrdValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	incomingCrd := &apiextensionsv1.CustomResourceDefinition{}
+
+	err := cv.decoder.Decode(req, incomingCrd)
+	if err != nil {
+		message := fmt.Sprintf("failed to decode CRD %q", req.Name)
+		cv.log.V(0).Error(err, message)
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("%s: %w", message, err))
+	}
+
+	err = crd.Validate(ctx, cv.client, incomingCrd)
+	if err != nil {
+		message := fmt.Sprintf("failed to validate safety of %s for CRD %q: %s", req.Operation, req.Name, err)
+		cv.log.V(0).Info(message)
+		return admission.Denied(message)
+	}
+
+	cv.log.Info("admission allowed for %s of CRD %q", req.Name, req.Operation)
+	return admission.Allowed("")
+}
+
+// InjectDecoder injects a decoder for the CrdValidator.
+func (cv *CrdValidator) InjectDecoder(d *admission.Decoder) error {
+	cv.decoder = d
+	return nil
+}

--- a/cmd/crdvalidator/main.go
+++ b/cmd/crdvalidator/main.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"github.com/operator-framework/rukpak/cmd/crdvalidator/handlers"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+var (
+	scheme   = runtime.NewScheme()
+	entryLog = log.Log.WithName("crdvalidator")
+)
+
+const defaultCertDir = "/etc/admission-webhook/tls"
+
+func init() {
+	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
+		entryLog.Error(err, "unable to set up crd scheme")
+		os.Exit(1)
+	}
+}
+
+func main() {
+	// Setup a Manager
+	entryLog.Info("setting up manager")
+	mgr, err := manager.New(config.GetConfigOrDie(), manager.Options{Scheme: scheme})
+	if err != nil {
+		entryLog.Error(err, "unable to set up overall controller manager")
+		os.Exit(1)
+	}
+
+	entryLog.Info("setting up webhook server")
+	hookServer := mgr.GetWebhookServer()
+
+	// Point to where cert-mgr is placing the cert
+	hookServer.CertDir = defaultCertDir
+
+	// Register CRD validation handler
+	entryLog.Info("registering webhooks to the webhook server")
+	crdValidatorHandler := handlers.NewCrdValidator(entryLog, mgr.GetClient())
+	hookServer.Register("/validate-crd", &webhook.Admission{
+		Handler: &crdValidatorHandler,
+	})
+
+	entryLog.Info("starting manager")
+	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+		entryLog.Error(err, "unable to run manager")
+		os.Exit(1)
+	}
+}

--- a/internal/util/name.go
+++ b/internal/util/name.go
@@ -1,0 +1,7 @@
+package util
+
+import "k8s.io/apimachinery/pkg/util/rand"
+
+func GenName(namePrefix string) string {
+	return namePrefix + rand.String(5)
+}

--- a/manifests/crdvalidator/00_namespace.yaml
+++ b/manifests/crdvalidator/00_namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crdvalidator-system

--- a/manifests/crdvalidator/01_cluster_role.yaml
+++ b/manifests/crdvalidator/01_cluster_role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crd-validation-webhook
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["list"]

--- a/manifests/crdvalidator/01_service_account.yaml
+++ b/manifests/crdvalidator/01_service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: crdvalidator-system
+  name: crd-validation-webhook

--- a/manifests/crdvalidator/02_cluster_role_binding.yaml
+++ b/manifests/crdvalidator/02_cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crd-validation-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crd-validation-webhook
+subjects:
+- kind: ServiceAccount
+  name: crd-validation-webhook
+  namespace: crdvalidator-system

--- a/manifests/crdvalidator/03_service.yaml
+++ b/manifests/crdvalidator/03_service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: crd-validation-webhook
+  namespace: crdvalidator-system
+spec:
+  ports:
+    - port: 9443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    app: crd-validation-webhook

--- a/manifests/crdvalidator/04_webhook.yaml
+++ b/manifests/crdvalidator/04_webhook.yaml
@@ -1,0 +1,42 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: crd-validation-webhook
+  annotations:
+    cert-manager.io/inject-ca-from: crdvalidator-system/crd-validation-webhook-certificate
+webhooks:
+  - name: "webhook.crdvalidator.io"
+    rules:
+    - apiGroups: ["apiextensions.k8s.io"]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["customresourcedefinitions"]
+      scope: "*"
+    clientConfig:
+      service:
+        namespace: crdvalidator-system
+        name: crd-validation-webhook
+        path: /validate-crd
+        port: 9443
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: crd-validation-webhook-certificate
+  namespace: crdvalidator-system
+spec:
+  secretName: crd-validation-webhook-certificate
+  dnsNames:
+    - crd-validation-webhook.crdvalidator-system.svc
+  issuerRef:
+    name: selfsigned
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned
+  namespace: crdvalidator-system
+spec:
+  selfSigned: {}

--- a/manifests/crdvalidator/05_deployment.yaml
+++ b/manifests/crdvalidator/05_deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crd-validation-webhook
+  namespace: crdvalidator-system
+spec:
+  selector:
+    matchLabels:
+      app: crd-validation-webhook
+  template:
+    metadata:
+      labels:
+        app: crd-validation-webhook
+    spec:
+      serviceAccountName: crd-validation-webhook
+      containers:
+        - image: quay.io/operator-framework/plain-provisioner:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/crdvalidator"]
+          name: crd-validation-webhook
+          volumeMounts:
+            - name: tls
+              mountPath: "/etc/admission-webhook/tls"
+      volumes:
+        - name: tls
+          secret:
+            secretName: crd-validation-webhook-certificate

--- a/manifests/crdvalidator/kustomization.yml
+++ b/manifests/crdvalidator/kustomization.yml
@@ -1,0 +1,8 @@
+resources:
+  - 00_namespace.yaml
+  - 01_cluster_role.yaml
+  - 01_service_account.yaml
+  - 02_cluster_role_binding.yaml
+  - 03_service.yaml
+  - 04_webhook.yaml
+  - 05_deployment.yaml

--- a/test/e2e/crdvalidator_test.go
+++ b/test/e2e/crdvalidator_test.go
@@ -1,0 +1,198 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/operator-framework/rukpak/internal/util"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	defaultTestingCrdName  = "samplecrd"
+	defaultTestingCrdGroup = "e2e.io"
+)
+
+var _ = Describe("crd validation webhook", func() {
+	When("a crd event is emitted", func() {
+		var ctx context.Context
+
+		BeforeEach(func() { ctx = context.Background() })
+		AfterEach(func() { ctx.Done() })
+
+		When("an incoming crd event is safe", func() {
+			var crd *apiextensionsv1.CustomResourceDefinition
+
+			BeforeEach(func() {
+				crd = newTestingCRD(
+					util.GenName(defaultTestingCrdName),
+					defaultTestingCrdGroup,
+					[]apiextensionsv1.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Served:  true,
+							Storage: true,
+							Schema: &apiextensionsv1.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+									Type:        "object",
+									Description: "my crd schema",
+								},
+							},
+						},
+					},
+				)
+
+				Eventually(func() error {
+					return c.Create(ctx, crd)
+				}).Should(Succeed(), "should be able to create a safe crd but was not")
+			})
+
+			AfterEach(func() {
+				By("deleting the testing crd")
+				Expect(c.Delete(ctx, crd)).To(BeNil())
+			})
+
+			It("should allow the crd update event to occur", func() {
+				Eventually(func() error {
+					if err := c.Get(ctx, client.ObjectKeyFromObject(crd), crd); err != nil {
+						return err
+					}
+
+					crd.Spec.Versions[0].Storage = false
+
+					crd.Spec.Versions = append(crd.Spec.Versions, apiextensionsv1.CustomResourceDefinitionVersion{
+						Name:    "v1alpha2",
+						Served:  true,
+						Storage: true,
+						Schema: &apiextensionsv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+								Type:        "object",
+								Description: "my crd schema",
+							},
+						},
+					})
+
+					return c.Update(ctx, crd)
+				}).Should(Succeed())
+			})
+		})
+
+		// TODO (tylerslaton): Check CRDValidator safe storage logic
+		//
+		// This test is currently trying to simulate a situtation where an incoming
+		// CRD removes a stored version. However, it does not work as expected because
+		// something (potentially the apiserver) is intervening first and not allowing
+		// it through. This is fine and ultimately what the safe storage logic of the
+		// CRDValidator was designed to prevent but is unknown why it is occurring. We
+		// Should come back to this test case, figure out what is preventing it from
+		// hitting the webhook and decide if we want to keep that logic or not.
+		PWhen("an incoming crd event removes a stored version", func() {
+			var crd *apiextensionsv1.CustomResourceDefinition
+
+			BeforeEach(func() {
+				crd = newTestingCRD(
+					util.GenName(defaultTestingCrdName),
+					defaultTestingCrdGroup,
+					[]apiextensionsv1.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1alpha1",
+							Served:  true,
+							Storage: true,
+							Schema: &apiextensionsv1.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+									Type:        "object",
+									Description: "my crd schema",
+								},
+							},
+						},
+						{
+							Name:    "v1alpha2",
+							Served:  true,
+							Storage: false,
+							Schema: &apiextensionsv1.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+									Type:        "object",
+									Description: "my crd schema",
+								},
+							},
+						},
+					},
+				)
+
+				Eventually(func() error {
+					return c.Create(ctx, crd)
+				}).Should(Succeed(), "should be able to create a safe crd but was not")
+			})
+
+			AfterEach(func() {
+				By("deleting the testing crd")
+				Expect(c.Delete(ctx, crd)).To(BeNil())
+			})
+
+			It("should deny admission", func() {
+				Eventually(func() string {
+					if err := c.Get(ctx, client.ObjectKeyFromObject(crd), crd); err != nil {
+						return err.Error()
+					}
+
+					newCRD := newTestingCRD(
+						crd.Spec.Names.Singular,
+						defaultTestingCrdGroup,
+						[]apiextensionsv1.CustomResourceDefinitionVersion{
+							{
+								Name:    "v1alpha2",
+								Served:  true,
+								Storage: true,
+								Schema: &apiextensionsv1.CustomResourceValidation{
+									OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+										Type:        "object",
+										Description: "my crd schema",
+									},
+								},
+							},
+							{
+								Name:    "v1alpha3",
+								Served:  true,
+								Storage: false,
+								Schema: &apiextensionsv1.CustomResourceValidation{
+									OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+										Type:        "object",
+										Description: "my crd schema",
+									},
+								},
+							},
+						},
+					)
+
+					newCRD.SetResourceVersion(crd.ResourceVersion)
+					newCRD.Status.StoredVersions = []string{"v1alpha2"}
+
+					return c.Update(ctx, newCRD).Error()
+				}).Should(ContainSubstring("cannot remove stored versions"))
+			})
+		})
+	})
+})
+
+func newTestingCRD(name, group string, versions []apiextensionsv1.CustomResourceDefinitionVersion) *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%v.%v", name, group),
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Scope:    apiextensionsv1.ClusterScoped,
+			Group:    group,
+			Versions: versions,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   name,
+				Singular: name,
+				Kind:     name,
+				ListKind: name + "List",
+			},
+		},
+	}
+}


### PR DESCRIPTION
_NOTES_ 
- This is an alternative approach to #199
- Adding a few E2E test cases for this logic
- This webhook is intended to eventually live in its own repository separate from RukPak components. The implementation has been done with that in mind.

# Summary
Doing a few things here that we should talk through:

- Creating a new webhook (`crdvalidator`) under the `cmd` directory. There has been talk of moving this webhook into its own repo in the future and this should make that very easy.
- Adding Makefile targets to deploy the webhook
- Moving the `crd` util package along side the webhook code.

# Open Questions
- Should this have an option to force `crd` applies through or would that option just be removing this webhook?

