### PR TITLE
e2e: Add test cases for BI/Bundle garbage collection

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -81,18 +81,28 @@ func MetadataConfigMapName(bundleName string) string {
 	return fmt.Sprintf("bundle-metadata-%s", bundleName)
 }
 
+func newLabelSelector(name, kind string) labels.Selector {
+	kindRequirement, err := labels.NewRequirement("core.rukpak.io/owner-kind", selection.Equals, []string{kind})
+	if err != nil {
+		return nil
+	}
+	nameRequirement, err := labels.NewRequirement("core.rukpak.io/owner-name", selection.Equals, []string{name})
+	if err != nil {
+		return nil
+	}
+	return labels.NewSelector().Add(*kindRequirement, *nameRequirement)
+}
+
 // NewBundleLabelSelector is responsible for constructing a label.Selector
 // for any underlying resources that are associated with the Bundle parameter.
 func NewBundleLabelSelector(bundle *rukpakv1alpha1.Bundle) labels.Selector {
-	bundleRequirement, err := labels.NewRequirement("core.rukpak.io/owner-kind", selection.Equals, []string{"Bundle"})
-	if err != nil {
-		return nil
-	}
-	bundleNameRequirement, err := labels.NewRequirement("core.rukpak.io/owner-name", selection.Equals, []string{bundle.GetName()})
-	if err != nil {
-		return nil
-	}
-	return labels.NewSelector().Add(*bundleRequirement, *bundleNameRequirement)
+	return newLabelSelector(bundle.GetName(), "Bundle")
+}
+
+// NewBundleInstanceLabelSelector is responsible for constructing a label.Selector
+// for any underlying resources that are associated with the BundleInstance parameter.
+func NewBundleInstanceLabelSelector(bi *rukpakv1alpha1.BundleInstance) labels.Selector {
+	return newLabelSelector(bi.GetName(), "BundleInstance")
 }
 
 func CreateOrRecreate(ctx context.Context, cl client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -6,8 +6,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/operator-framework/rukpak/api/v1alpha1"
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,10 +29,13 @@ var _ = BeforeSuite(func() {
 	config := ctrl.GetConfigOrDie()
 
 	scheme := runtime.NewScheme()
-	err := v1alpha1.AddToScheme(scheme)
+	err := rukpakv1alpha1.AddToScheme(scheme)
 	Expect(err).To(BeNil())
 
 	err = corev1.AddToScheme(scheme)
+	Expect(err).To(BeNil())
+
+	err = apiextensionsv1.AddToScheme(scheme)
 	Expect(err).To(BeNil())
 
 	c, err = client.New(config, client.Options{Scheme: scheme})


### PR DESCRIPTION
Introduce a new top-level describe for ensuring that the underlying resources used by the Bundle/BI controllers are properly garbage collected once those resources are deleted from the cluster.

Closes #188 