### PR TITLE
e2e: Automatically inject a newline escape character in the Logf function

### DIFF
--- a/test/e2e/plain_provisioner_test.go
+++ b/test/e2e/plain_provisioner_test.go
@@ -30,6 +30,9 @@ const (
 )
 
 func Logf(f string, v ...interface{}) {
+	if !strings.HasSuffix(f, "\n") {
+		f += "\n"
+	}
 	fmt.Fprintf(GinkgoWriter, f, v...)
 }
 


### PR DESCRIPTION
Update the Logf helper function which wraps the GinkgoWriter() utility and automatically inject a newline escape character when the input string doesn't already contain that.