### PR TITLE
(doc): git-based bundles with custom directory specified 

### DIFF
--- a/docs/git-bundles.md
+++ b/docs/git-bundles.md
@@ -8,8 +8,12 @@ make it available within the cluster.
 
 The git repository backing the bundle, or "bundle git repo", must have a certain structure in order to produce a valid
 plain Bundle. It should have a directory where the Kubernetes manifests are stored -- this directory is used when
-copying manifests onto the cluster. By default, this directory is assumed to be `/manifests` at the top level. For an
-example of a bundle git repo that conforms to the specifications, see
+copying manifests onto the cluster. By default, this directory is assumed to be `/manifests` at the root level, but can
+be specified via `spec.source.git.directory`.
+
+> Note: There must be a `manifests` directory in the provided directory in order to have a valid bundle git repo.
+
+For an example of a bundle git repo that conforms to the specifications, see
 the [combo repository](https://github.com/operator-framework/combo/).
 
 When creating a Bundle from a git source, a reference to a particular commit, tag, or branch must be provided for the

--- a/docs/plain-bundle-spec.md
+++ b/docs/plain-bundle-spec.md
@@ -70,8 +70,10 @@ on bundles backed by git repositories, see the [git based bundles doc](git-bundl
 * The static manifests must be located in the root-level /manifests directory in a bundle image for the bundle to be a
   valid `plain+v0` bundle that the provisioner can unpack. A plain bundle image without a /manifests directory is
   invalid and will not be successfully unpacked onto the cluster.
-* For a bundle git repo, this limitation does not exist, and the manifests can be in any directory in the repository.
-  The manifest directory is assumed to be ./manifests in a bundle git repo but can be provided at runtime.
+* For a bundle git repo, the manifests directory can be anywhere in the repository, not just at the root-level. The
+  location can be specified via `spec.source.git.directory`. There must be a `manifests` directory at the provided
+  location in order to have a valid bundle git repo. If a specific directory is not provided, it is assumed to be
+  ./manifests in a bundle git repo.
 * The manifests directory should be flat: all manifests should be at the top-level with no subdirectories.
 * The plain bundle image can be built from any base image, but `scratch` is recommended as it keeps the resulting bundle
   image a minimal size.


### PR DESCRIPTION
This PR adds additional documentation for bundles with custom bundle directory roots. 