### PR TITLE
internal/git/git.go: fix copying of bundle root

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -38,18 +38,18 @@ func (c *checkoutCmd) String() string {
 	}
 
 	if commit != "" {
-		checkoutCommand = fmt.Sprintf("git clone %s %s && cd %s && git checkout %s && rm -r .git && cp -r %s /bundle",
+		checkoutCommand = fmt.Sprintf("git clone %s %s && cd %s && git checkout %s && rm -r .git && cp -r %s/. /bundle",
 			repository, repositoryName, repositoryName, commit, directory)
 		return checkoutCommand
 	}
 
 	if tag != "" {
-		checkoutCommand = fmt.Sprintf("git clone --depth 1 --branch %s %s %s && cd %s && git checkout tags/%s && rm -r .git && cp -r %s /bundle",
+		checkoutCommand = fmt.Sprintf("git clone --depth 1 --branch %s %s %s && cd %s && git checkout tags/%s && rm -r .git && cp -r %s/. /bundle",
 			tag, repository, repositoryName, repositoryName, tag, directory)
 		return checkoutCommand
 	}
 
-	checkoutCommand = fmt.Sprintf("git clone --depth 1 --branch %s %s %s && cd %s && git checkout %s && rm -r .git && cp -r %s /bundle",
+	checkoutCommand = fmt.Sprintf("git clone --depth 1 --branch %s %s %s && cd %s && git checkout %s && rm -r .git && cp -r %s/. /bundle",
 		branch, repository, repositoryName, repositoryName, branch, directory)
 	return checkoutCommand
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -21,7 +21,7 @@ func TestCheckoutCommand(t *testing.T) {
 					Commit: "4567031e158b42263e70a7c63e29f8981a4a6135",
 				},
 			},
-			expected: fmt.Sprintf("git clone %s %s && cd %s && git checkout %s && rm -r .git && cp -r %s /bundle",
+			expected: fmt.Sprintf("git clone %s %s && cd %s && git checkout %s && rm -r .git && cp -r %s/. /bundle",
 				"https://github.com/operator-framework/combo", repositoryName, repositoryName, "4567031e158b42263e70a7c63e29f8981a4a6135",
 				"./"),
 		},
@@ -32,7 +32,7 @@ func TestCheckoutCommand(t *testing.T) {
 					Tag: "v0.0.1",
 				},
 			},
-			expected: fmt.Sprintf("git clone --depth 1 --branch %s %s %s && cd %s && git checkout tags/%s && rm -r .git && cp -r %s /bundle",
+			expected: fmt.Sprintf("git clone --depth 1 --branch %s %s %s && cd %s && git checkout tags/%s && rm -r .git && cp -r %s/. /bundle",
 				"v0.0.1", "https://github.com/operator-framework/combo", repositoryName, repositoryName, "v0.0.1", "./"),
 		},
 		{
@@ -43,7 +43,7 @@ func TestCheckoutCommand(t *testing.T) {
 					Branch: "dev",
 				},
 			},
-			expected: fmt.Sprintf("git clone --depth 1 --branch %s %s %s && cd %s && git checkout %s && rm -r .git && cp -r %s /bundle",
+			expected: fmt.Sprintf("git clone --depth 1 --branch %s %s %s && cd %s && git checkout %s && rm -r .git && cp -r %s/. /bundle",
 				"dev", "https://github.com/operator-framework/combo", repositoryName, repositoryName, "dev", "./deploy"),
 		},
 		{

--- a/test/e2e/plain_provisioner_test.go
+++ b/test/e2e/plain_provisioner_test.go
@@ -548,7 +548,7 @@ var _ = Describe("plain provisioner bundle", func() {
 							Type: rukpakv1alpha1.SourceTypeGit,
 							Git: &rukpakv1alpha1.GitSource{
 								Repository: "https://github.com/exdx/combo-bundle",
-								Directory:  "./dev/deploy/manifests",
+								Directory:  "./dev/deploy",
 								Ref: rukpakv1alpha1.GitRef{
 									Branch: "main",
 								},


### PR DESCRIPTION
This commit copies the _contents_ of the bundle directory into `/bundle` rather than the specified bundle directory itself.

This resolves an issue where if `spec.source.git.directory` specified `path/to/root` (where `path/to/root` contains a `manifests` directory at `path/to/root/manifests`, the unpacked `/bundle` directory would contain `/bundle/root/manifests`, when it should contain `/bundle/manifests`.

I introduced this bug in #211 as part of those fixes.