### PR TITLE
Makefile: Add support for overriding the IMAGE_* variables locally

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,6 @@ env:
 - GO111MODULE=on
 - CGO_ENABLED=0
 - PKG=github.com/operator-framework/rukpak/internal/version
-- IMAGE_REPO=quay.io/operator-framework/plain-provisioner
 before:
   hooks:
     - go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 ###########################
 ORG := github.com/operator-framework
 PKG := $(ORG)/rukpak
-IMAGE_REPO=quay.io/operator-framework/plain-provisioner
-IMAGE_TAG=latest
+export IMAGE_REPO ?= quay.io/operator-framework/plain-provisioner
+export IMAGE_TAG ?= latest
 IMAGE?=$(IMAGE_REPO):$(IMAGE_TAG)
 KIND_CLUSTER_NAME ?= kind
 KIND := kind


### PR DESCRIPTION
Avoid hardcoding the env.IMAGE_REPO in the goreleaser configuration as we can infer that information from the Makefile when running the release target. Add support for overriding the IMAGE_REPO and IMAGE_TAG variables.

Signed-off-by: timflannagan <timflannagan@gmail.com>