### PR TITLE
test(crdvalidator): add e2e test case for a crd update that breaks an existing cr

### DIFF
--- a/test/e2e/crdvalidator_test.go
+++ b/test/e2e/crdvalidator_test.go
@@ -9,11 +9,13 @@ import (
 	"github.com/operator-framework/rukpak/internal/util"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
 	defaultTestingCrdName  = "samplecrd"
+	defaultTestingCrName   = "samplecr"
 	defaultTestingCrdGroup = "e2e.io"
 )
 
@@ -30,20 +32,17 @@ var _ = Describe("crd validation webhook", func() {
 			BeforeEach(func() {
 				crd = newTestingCRD(
 					util.GenName(defaultTestingCrdName),
-					defaultTestingCrdGroup,
-					[]apiextensionsv1.CustomResourceDefinitionVersion{
-						{
-							Name:    "v1alpha1",
-							Served:  true,
-							Storage: true,
-							Schema: &apiextensionsv1.CustomResourceValidation{
-								OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-									Type:        "object",
-									Description: "my crd schema",
-								},
+					[]apiextensionsv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: true,
+						Schema: &apiextensionsv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+								Type:        "object",
+								Description: "my crd schema",
 							},
 						},
-					},
+					}},
 				)
 
 				Eventually(func() error {
@@ -96,7 +95,6 @@ var _ = Describe("crd validation webhook", func() {
 			BeforeEach(func() {
 				crd = newTestingCRD(
 					util.GenName(defaultTestingCrdName),
-					defaultTestingCrdGroup,
 					[]apiextensionsv1.CustomResourceDefinitionVersion{
 						{
 							Name:    "v1alpha1",
@@ -141,7 +139,6 @@ var _ = Describe("crd validation webhook", func() {
 
 					newCRD := newTestingCRD(
 						crd.Spec.Names.Singular,
-						defaultTestingCrdGroup,
 						[]apiextensionsv1.CustomResourceDefinitionVersion{
 							{
 								Name:    "v1alpha2",
@@ -171,21 +168,85 @@ var _ = Describe("crd validation webhook", func() {
 					newCRD.SetResourceVersion(crd.ResourceVersion)
 					newCRD.Status.StoredVersions = []string{"v1alpha2"}
 
-					return c.Update(ctx, newCRD).Error()
+					err := c.Update(ctx, newCRD)
+					if err != nil {
+						return err.Error()
+					}
+					return ""
 				}).Should(ContainSubstring("cannot remove stored versions"))
+			})
+		})
+
+		When("an incoming crd event modifies the schema in a way that breaks an existing cr", func() {
+			var crd *apiextensionsv1.CustomResourceDefinition
+
+			BeforeEach(func() {
+				crd = newTestingCRD(
+					util.GenName(defaultTestingCrdName),
+					[]apiextensionsv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: true,
+						Schema: &apiextensionsv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+								Type:        "object",
+								Description: "my crd schema",
+								Properties: map[string]apiextensionsv1.JSONSchemaProps{
+									"sampleProperty": {Type: "string"},
+								},
+							},
+						},
+					}},
+				)
+
+				Eventually(func() error {
+					return c.Create(ctx, crd)
+				}).Should(Succeed(), "should be able to create a safe crd but was not")
+
+				// Build up a CR to create out of unstructured.Unstructured
+				sampleCR := &unstructured.Unstructured{}
+				sampleCR.SetKind(crd.Spec.Names.Singular)
+				sampleCR.SetAPIVersion(defaultTestingCrdGroup + "/" + "v1alpha1")
+				sampleCR.SetGenerateName(defaultTestingCrName)
+				Eventually(func() error {
+					return c.Create(ctx, sampleCR)
+				}).Should(Succeed(), "should be able to create a cr for the sample crd but was not")
+
+			})
+
+			AfterEach(func() {
+				By("deleting the testing crd")
+				Expect(c.Delete(ctx, crd)).To(BeNil())
+			})
+
+			It("should deny admission", func() {
+				Eventually(func() string {
+					if err := c.Get(ctx, client.ObjectKeyFromObject(crd), crd); err != nil {
+						return err.Error()
+					}
+
+					// Update the v1alpha1 schema to invalidate existing CR created in BeforeEach()
+					crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Required = []string{"sampleProperty"}
+
+					err := c.Update(ctx, crd)
+					if err != nil {
+						return err.Error()
+					}
+					return ""
+				}).Should(ContainSubstring("error validating existing CRs against new CRD's schema"))
 			})
 		})
 	})
 })
 
-func newTestingCRD(name, group string, versions []apiextensionsv1.CustomResourceDefinitionVersion) *apiextensionsv1.CustomResourceDefinition {
+func newTestingCRD(name string, versions []apiextensionsv1.CustomResourceDefinitionVersion) *apiextensionsv1.CustomResourceDefinition {
 	return &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%v.%v", name, group),
+			Name: fmt.Sprintf("%v.%v", name, defaultTestingCrdGroup),
 		},
 		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 			Scope:    apiextensionsv1.ClusterScoped,
-			Group:    group,
+			Group:    defaultTestingCrdGroup,
 			Versions: versions,
 			Names: apiextensionsv1.CustomResourceDefinitionNames{
 				Plural:   name,


### PR DESCRIPTION
Adding a new test case to the `crdvalidator` e2e suite that prevents a schema update from breaking an existing CR.