### PR TITLE
test(crdvalidator): add unit testing for underlying crd validation package

### DIFF
--- a/internal/crd/crd_test.go
+++ b/internal/crd/crd_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/operator-framework/rukpak/internal/unit"
-	"github.com/operator-framework/rukpak/internal/util"
+	"github.com/operator-framework/rukpak/test/testutil"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -146,10 +146,10 @@ func TestValidate(t *testing.T) {
 			defer ctx.Done()
 
 			// Create needed structs for testing using uniquely generated names
-			existingCrd := util.NewTestingCRD("samplecrd", "e2e.io", true, tt.existingCrdVersions)
+			existingCrd := testutil.NewTestingCRD("", testutil.DefaultGroup, tt.existingCrdVersions)
 			uniqueName := existingCrd.Spec.Names.Singular
-			existingCr := util.NewTestingCR("samplecr", "e2e.io", tt.existingCrVersion, uniqueName)
-			newCrd := util.NewTestingCRD(uniqueName, "e2e.io", false, tt.newCrdVersions)
+			existingCr := testutil.NewTestingCR(testutil.DefaultCrName, testutil.DefaultGroup, tt.existingCrVersion, uniqueName)
+			newCrd := testutil.NewTestingCRD(uniqueName, testutil.DefaultGroup, tt.newCrdVersions)
 
 			// Create existing CRD
 			err := kubeclient.Create(ctx, existingCrd)

--- a/internal/crd/crd_test.go
+++ b/internal/crd/crd_test.go
@@ -1,0 +1,181 @@
+package crd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/operator-framework/rukpak/internal/unit"
+	"github.com/operator-framework/rukpak/internal/util"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestValidate(t *testing.T) {
+	// Setup envtest client
+	kubeclient, err := unit.SetupClient()
+	require.NoError(t, err, "failed to create kube client")
+
+	// Setup defaults for eventually calls
+	defaultWaitPeriod := time.Second * 15
+	defaultTick := time.Second * 1
+
+	for _, tt := range []struct {
+		name                string
+		errString           string
+		existingCrVersion   string
+		existingCrdVersions []apiextensionsv1.CustomResourceDefinitionVersion
+		newCrdVersions      []apiextensionsv1.CustomResourceDefinitionVersion
+	}{
+		{
+			name:              "validates a safe crd upgrade",
+			errString:         "",
+			existingCrVersion: "v1alpha1",
+			existingCrdVersions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha1",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type:        "object",
+							Description: "my crd schema",
+						},
+					},
+				},
+			},
+			newCrdVersions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha1",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type:        "object",
+							Description: "my crd schema",
+						},
+					},
+				},
+				{
+					Name:    "v1alpha2",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type:        "object",
+							Description: "my crd schema",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:              "invalidates a crd upgrade that removes a stored version",
+			errString:         "cannot remove stored versions",
+			existingCrVersion: "v1alpha1",
+			existingCrdVersions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha1",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type:        "object",
+							Description: "my crd schema",
+						},
+					},
+				},
+			},
+			newCrdVersions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha2",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type:        "object",
+							Description: "my crd schema",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:              "invalidates a crd upgrade that breaks an existing cr",
+			errString:         "failed validation for new schema",
+			existingCrVersion: "v1alpha1",
+			existingCrdVersions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha1",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type:        "object",
+							Description: "my crd schema",
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"sampleProperty": {Type: "string"},
+							},
+						},
+					},
+				},
+			},
+			newCrdVersions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1alpha1",
+					Served:  true,
+					Storage: true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Type:        "object",
+							Description: "my crd schema",
+							Required:    []string{"sampleProperty"},
+							Properties: map[string]apiextensionsv1.JSONSchemaProps{
+								"sampleProperty": {Type: "string"},
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			defer ctx.Done()
+
+			// Create needed structs for testing using uniquely generated names
+			existingCrd := util.NewTestingCRD("samplecrd", "e2e.io", true, tt.existingCrdVersions)
+			uniqueName := existingCrd.Spec.Names.Singular
+			existingCr := util.NewTestingCR("samplecr", "e2e.io", tt.existingCrVersion, uniqueName)
+			newCrd := util.NewTestingCRD(uniqueName, "e2e.io", false, tt.newCrdVersions)
+
+			// Create existing CRD
+			err := kubeclient.Create(ctx, existingCrd)
+			require.NoError(t, err, "failed to create initial crd for testing")
+			require.Eventuallyf(t, func() bool {
+				return kubeclient.Get(ctx, client.ObjectKeyFromObject(existingCrd), existingCrd) == nil
+			}, defaultWaitPeriod, defaultTick, "failed to get initial crd for testing: %v", err)
+
+			// Creating existing CR
+			err = kubeclient.Create(ctx, existingCr)
+			require.NoError(t, err, "failed to create initial cr for testing")
+			require.Eventuallyf(t, func() bool {
+				return kubeclient.Get(ctx, client.ObjectKeyFromObject(existingCr), existingCr) == nil
+			}, defaultWaitPeriod, defaultTick, "failed to get initial cr for testing: %v", err)
+
+			// Run Validate and check that the error is not nil and we were not expecting it to be nil
+			err = Validate(ctx, kubeclient, newCrd)
+			if err != nil && tt.errString != "" {
+				require.ErrorContains(t, err, tt.errString)
+			}
+
+			// Cleanup resources
+			err = kubeclient.Delete(ctx, existingCr)
+			require.NoError(t, err, "failed to delete initial cr for testing")
+			err = kubeclient.Delete(ctx, existingCrd)
+			require.NoError(t, err, "failed to delete initial crd for testing")
+		})
+	}
+}

--- a/internal/util/kubestructs.go
+++ b/internal/util/kubestructs.go
@@ -1,0 +1,39 @@
+package util
+
+import (
+	"fmt"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func NewTestingCRD(name, group string, unique bool, versions []apiextensionsv1.CustomResourceDefinitionVersion) *apiextensionsv1.CustomResourceDefinition {
+	if unique {
+		name = GenName(name)
+	}
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%v.%v", name, group),
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Scope:    apiextensionsv1.ClusterScoped,
+			Group:    group,
+			Versions: versions,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   name,
+				Singular: name,
+				Kind:     name,
+				ListKind: name + "List",
+			},
+		},
+	}
+}
+
+func NewTestingCR(name, group, version, kind string) *unstructured.Unstructured {
+	newTestingCr := &unstructured.Unstructured{}
+	newTestingCr.SetKind(kind)
+	newTestingCr.SetAPIVersion(group + "/" + version)
+	newTestingCr.SetGenerateName(name)
+	return newTestingCr
+}

--- a/test/e2e/crdvalidator_test.go
+++ b/test/e2e/crdvalidator_test.go
@@ -5,15 +5,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/operator-framework/rukpak/internal/util"
+	"github.com/operator-framework/rukpak/test/testutil"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	defaultTestingCrdName  = "samplecrd"
-	defaultTestingCrName   = "samplecr"
-	defaultTestingCrdGroup = "e2e.io"
 )
 
 var _ = Describe("crd validation webhook", func() {
@@ -27,7 +21,7 @@ var _ = Describe("crd validation webhook", func() {
 			var crd *apiextensionsv1.CustomResourceDefinition
 
 			BeforeEach(func() {
-				crd = util.NewTestingCRD(defaultTestingCrdName, defaultTestingCrdGroup, true,
+				crd = testutil.NewTestingCRD("", testutil.DefaultGroup,
 					[]apiextensionsv1.CustomResourceDefinitionVersion{
 						{
 							Name:    "v1alpha1",
@@ -91,7 +85,7 @@ var _ = Describe("crd validation webhook", func() {
 			var crd *apiextensionsv1.CustomResourceDefinition
 
 			BeforeEach(func() {
-				crd = util.NewTestingCRD(defaultTestingCrdName, defaultTestingCrdGroup, true,
+				crd = testutil.NewTestingCRD("", testutil.DefaultGroup,
 					[]apiextensionsv1.CustomResourceDefinitionVersion{
 						{
 							Name:    "v1alpha1",
@@ -134,7 +128,7 @@ var _ = Describe("crd validation webhook", func() {
 						return err.Error()
 					}
 
-					newCRD := util.NewTestingCRD(crd.Spec.Names.Singular, defaultTestingCrdGroup, false,
+					newCRD := testutil.NewTestingCRD(crd.Spec.Names.Singular, testutil.DefaultGroup,
 						[]apiextensionsv1.CustomResourceDefinitionVersion{
 							{
 								Name:    "v1alpha2",
@@ -177,7 +171,7 @@ var _ = Describe("crd validation webhook", func() {
 			var crd *apiextensionsv1.CustomResourceDefinition
 
 			BeforeEach(func() {
-				crd = util.NewTestingCRD(defaultTestingCrdName, defaultTestingCrdGroup, true, []apiextensionsv1.CustomResourceDefinitionVersion{{
+				crd = testutil.NewTestingCRD("", testutil.DefaultGroup, []apiextensionsv1.CustomResourceDefinitionVersion{{
 					Name:    "v1alpha1",
 					Served:  true,
 					Storage: true,
@@ -198,7 +192,7 @@ var _ = Describe("crd validation webhook", func() {
 				}).Should(Succeed(), "should be able to create a safe crd but was not")
 
 				// Build up a CR to create out of unstructured.Unstructured
-				sampleCR := util.NewTestingCR(defaultTestingCrName, defaultTestingCrdGroup, "v1alpha1", crd.Spec.Names.Singular)
+				sampleCR := testutil.NewTestingCR(testutil.DefaultCrName, testutil.DefaultGroup, "v1alpha1", crd.Spec.Names.Singular)
 				Eventually(func() error {
 					return c.Create(ctx, sampleCR)
 				}).Should(Succeed(), "should be able to create a cr for the sample crd but was not")

--- a/test/e2e/crdvalidator_test.go
+++ b/test/e2e/crdvalidator_test.go
@@ -198,7 +198,7 @@ var _ = Describe("crd validation webhook", func() {
 				}).Should(Succeed(), "should be able to create a safe crd but was not")
 
 				// Build up a CR to create out of unstructured.Unstructured
-				sampleCR := util.NewTestingCR(defaultTestingCrName, crd.Spec.Names.Singular, defaultTestingCrdGroup, "v1alpha1")
+				sampleCR := util.NewTestingCR(defaultTestingCrName, defaultTestingCrdGroup, "v1alpha1", crd.Spec.Names.Singular)
 				Eventually(func() error {
 					return c.Create(ctx, sampleCR)
 				}).Should(Succeed(), "should be able to create a cr for the sample crd but was not")

--- a/test/testutil/constants.go
+++ b/test/testutil/constants.go
@@ -1,0 +1,7 @@
+package testutil
+
+const (
+	DefaultCrdName = "samplecrd"
+	DefaultCrName  = "samplecr"
+	DefaultGroup   = "e2e.io"
+)

--- a/test/testutil/name.go
+++ b/test/testutil/name.go
@@ -1,4 +1,4 @@
-package util
+package testutil
 
 import "k8s.io/apimachinery/pkg/util/rand"
 

--- a/test/testutil/structs.go
+++ b/test/testutil/structs.go
@@ -1,4 +1,4 @@
-package util
+package testutil
 
 import (
 	"fmt"
@@ -8,9 +8,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func NewTestingCRD(name, group string, unique bool, versions []apiextensionsv1.CustomResourceDefinitionVersion) *apiextensionsv1.CustomResourceDefinition {
-	if unique {
-		name = GenName(name)
+func NewTestingCRD(name, group string, versions []apiextensionsv1.CustomResourceDefinitionVersion) *apiextensionsv1.CustomResourceDefinition {
+	if name == "" {
+		name = GenName(DefaultCrdName)
 	}
 	return &apiextensionsv1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/testutil/structs.go
+++ b/test/testutil/structs.go
@@ -8,6 +8,8 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+// NewTestingCRD takes a name, group and versions to be set for a new CRD. If name is set to ""
+// then it will run testutil.GenName() on it with the DefaultCrdName.
 func NewTestingCRD(name, group string, versions []apiextensionsv1.CustomResourceDefinitionVersion) *apiextensionsv1.CustomResourceDefinition {
 	if name == "" {
 		name = GenName(DefaultCrdName)
@@ -30,10 +32,33 @@ func NewTestingCRD(name, group string, versions []apiextensionsv1.CustomResource
 	}
 }
 
+// NewTestingCR takes a name, group, version and king in order to create a
+// new CR of a resource correctly.
 func NewTestingCR(name, group, version, kind string) *unstructured.Unstructured {
 	newTestingCr := &unstructured.Unstructured{}
 	newTestingCr.SetKind(kind)
 	newTestingCr.SetAPIVersion(group + "/" + version)
 	newTestingCr.SetGenerateName(name)
 	return newTestingCr
+}
+
+// CrdReady takes a CRD's status and determines if it is ready to accept new CRs
+func CrdReady(status *apiextensionsv1.CustomResourceDefinitionStatus) bool {
+	if status == nil {
+		return false
+	}
+	established, namesAccepted := false, false
+	for _, cdt := range status.Conditions {
+		switch cdt.Type {
+		case apiextensionsv1.Established:
+			if cdt.Status == apiextensionsv1.ConditionTrue {
+				established = true
+			}
+		case apiextensionsv1.NamesAccepted:
+			if cdt.Status == apiextensionsv1.ConditionTrue {
+				namesAccepted = true
+			}
+		}
+	}
+	return established && namesAccepted
 }


### PR DESCRIPTION
In addition I am moving the `NewTestingCRD` function into a new `testutil` package in `test` along side a new function called `NewTestingCR` to streamline the creation of these resources.