### PR TITLE
manifests: Add a base kustomization.yaml for the set of provisioner manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,15 +92,15 @@ kind-cluster: ## Standup a kind cluster for e2e testing usage
 ###################
 # Install and Run #
 ###################
-.PHONY: install-apis install-plain install-crdvalidator-webhook install-core-webhook install-webhooks run cert-mgr
+.PHONY: install-apis install-provisioners install-crdvalidator-webhook install-core-webhook install-webhooks run cert-mgr
 
 ##@ install/run:
 
 install-apis: generate kustomize ## Install the core rukpak CRDs
 	$(KUSTOMIZE) build manifests/apis/crds | kubectl apply -f -
 
-install-plain: kustomize ## Install the plain provisioner
-	$(KUSTOMIZE) build manifests/provisioners/plain | kubectl apply -f -
+install-provisioners: kustomize ## Install the plain provisioner
+	$(KUSTOMIZE) build manifests/provisioners | kubectl apply -f -
 
 install-crdvalidator-webhook: kustomize ## Install the crdvalidator webhook to the current cluster.
 	$(KUSTOMIZE) build manifests/crdvalidator | kubectl apply -f -
@@ -110,7 +110,7 @@ install-core-webhook: kustomize ## Install the core bundle webhook to the curren
 
 install-webhooks: cert-mgr install-crdvalidator-webhook install-core-webhook ## Install all webhooks to the current cluster
 
-run: build-container kind-load install-apis install-webhooks install-plain ## Build image and run operator in-cluster
+run: build-container kind-load install-apis install-webhooks install-provisioners ## Build image and run operator in-cluster
 
 cert-mgr: ## Install the certification manager
 	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MGR_VERSION)/cert-manager.yaml

--- a/manifests/provisioners/kustomization.yaml
+++ b/manifests/provisioners/kustomization.yaml
@@ -1,0 +1,3 @@
+bases:
+- ./plain
+


### PR DESCRIPTION
Update the manifests/provisioner directory structure and add a base kustomization.yaml that only points to the plain provisioner kustomization right now. This allows people to run `kustomize build manifests/provisioners` locally without having to specify the manifests/provisioners/plain directory, which makes it easier to script around when generating release artifacts.


Signed-off-by: timflannagan <timflannagan@gmail.com>