### PR TITLE
Introduce framework to emit prometheus metrics from plain provisioner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ vendor/
 bin/
 dist/
 .goreleaser.yml
+
+# Editor specific directories
+.vscode/

--- a/api/v1alpha1/bundle_types.go
+++ b/api/v1alpha1/bundle_types.go
@@ -22,6 +22,8 @@ import (
 
 type BundleConditionType string
 
+type BundlePhase string
+
 const (
 	SourceTypeImage = "image"
 	SourceTypeGit   = "git"
@@ -33,10 +35,11 @@ const (
 	ReasonUnpackSuccessful = "UnpackSuccessful"
 	ReasonUnpackFailed     = "UnpackFailed"
 
-	PhasePending   = "Pending"
-	PhaseUnpacking = "Unpacking"
-	PhaseFailing   = "Failing"
-	PhaseUnpacked  = "Unpacked"
+	PhasePending   = BundlePhase("Pending")
+	PhaseUnpacking = BundlePhase("Unpacking")
+	PhaseFailing   = BundlePhase("Failing")
+	PhaseUnpacked  = BundlePhase("Unpacked")
+	PhaseUnknown   = BundlePhase("Unknown")
 )
 
 // BundleSpec defines the desired state of Bundle

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/onsi/gomega v1.18.1
 	github.com/operator-framework/api v0.13.0
 	github.com/operator-framework/helm-operator-plugins v0.0.9
+	github.com/prometheus/client_golang v1.12.1
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.1
 	helm.sh/helm/v3 v3.8.0
@@ -105,10 +106,9 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
-	github.com/prometheus/common v0.28.0 // indirect
-	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/prometheus/common v0.32.1 // indirect
+	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/rubenv/sql-migrate v0.0.0-20210614095031-55d5740dbbcc // indirect
 	github.com/russross/blackfriday v1.5.2 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
@@ -130,7 +130,7 @@ require (
 	golang.org/x/net v0.0.0-20220107192237-5cfca573fb4d // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect

--- a/go.sum
+++ b/go.sum
@@ -1150,8 +1150,9 @@ github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQ
 github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeDPbaTKGT+JTgUa3og=
 github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
-github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
+github.com/prometheus/client_golang v1.12.1 h1:ZiaPsmm9uiBeaSMRznKsCDNtPCS0T3JVDGF+06gjBzk=
+github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -1170,8 +1171,9 @@ github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt2
 github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
-github.com/prometheus/common v0.28.0 h1:vGVfV9KrDTvWt5boZO0I19g2E3CsWfpPPKZM9dt3mEw=
 github.com/prometheus/common v0.28.0/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
+github.com/prometheus/common v0.32.1 h1:hWIdL3N2HoUx3B8j3YN9mWor0qhY/NlEKZEaXxuIRh4=
+github.com/prometheus/common v0.32.1/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
 github.com/prometheus/procfs v0.0.0-20180125133057-cb4147076ac7/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -1183,8 +1185,9 @@ github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
-github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
+github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
@@ -1712,8 +1715,9 @@ golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211029165221-6e7872819dc8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
+golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/internal/provisioner/plain/controllers/bundleinstance_controller.go
+++ b/internal/provisioner/plain/controllers/bundleinstance_controller.go
@@ -120,7 +120,7 @@ func (r *BundleInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		var bnuErr *errBundleNotUnpacked
 		if errors.As(err, &bnuErr) {
 			reason := fmt.Sprintf("BundleUnpack%s", b.Status.Phase)
-			if b.Status.Phase == rukpakv1alpha1.PhaseUnpacking {
+			if b.Status.Phase == string(rukpakv1alpha1.PhaseUnpacking) {
 				reason = "BundleUnpackRunning"
 			}
 			meta.SetStatusCondition(&bi.Status.Conditions, metav1.Condition{
@@ -320,7 +320,7 @@ func (r *BundleInstanceReconciler) loadBundle(ctx context.Context, bi *rukpakv1a
 	if err := r.Get(ctx, types.NamespacedName{Name: bi.Spec.BundleName}, b); err != nil {
 		return nil, fmt.Errorf("get bundle %q: %w", bi.Spec.BundleName, err)
 	}
-	if b.Status.Phase != rukpakv1alpha1.PhaseUnpacked {
+	if b.Status.Phase != string(rukpakv1alpha1.PhaseUnpacked) {
 		return nil, &errBundleNotUnpacked{currentPhase: b.Status.Phase}
 	}
 

--- a/internal/provisioner/plain/main.go
+++ b/internal/provisioner/plain/main.go
@@ -36,6 +36,7 @@ import (
 
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	"github.com/operator-framework/rukpak/internal/provisioner/plain/controllers"
+	"github.com/operator-framework/rukpak/internal/provisioner/plain/metrics"
 	"github.com/operator-framework/rukpak/internal/storage"
 	"github.com/operator-framework/rukpak/internal/util"
 	"github.com/operator-framework/rukpak/internal/version"
@@ -159,7 +160,7 @@ func main() {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
-
+	metrics.ServeMetrics()
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")

--- a/internal/provisioner/plain/metrics/metrics.go
+++ b/internal/provisioner/plain/metrics/metrics.go
@@ -1,0 +1,100 @@
+package metrics
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
+
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+)
+
+const (
+	// metricsPath is the path that the provisioner exposes its metrics at.
+	metricsPath = "/metrics"
+
+	// metricsPort is the port that the provisioner exposes its metrics over http.
+	metricsPort = 8383
+)
+
+const (
+	nameLabel      = "Name"
+	namespaceLabel = "Namespace"
+)
+
+var (
+	bundleGaugeVec = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "bundle",
+			Help: "Bundle Infomation. A positive value represents successful bundle unpack. A zero value represents bundle unpacking is pending. A negative value represents bundle unpacking has failed.",
+		},
+		[]string{nameLabel, namespaceLabel},
+	)
+)
+
+// ServeMetrics enables the provisioner to serve prometheus metrics.
+func ServeMetrics() error {
+	// Register metrics for the operator with the prometheus.
+	logrus.Info("[metrics] Registering provisioner metrics")
+
+	err := registerMetrics()
+	if err != nil {
+		logrus.Infof("[metrics] Unable to register provisioner metrics: %v", err)
+		return err
+	}
+
+	// Start the server and expose the registered metrics.
+	logrus.Info("[metrics] Serving provisioner metrics")
+	http.Handle(metricsPath, promhttp.Handler())
+
+	go func() {
+		err := http.ListenAndServe(fmt.Sprintf(":%d", metricsPort), nil)
+		if err != nil {
+			if err == http.ErrServerClosed {
+				logrus.Errorf("Metrics (http) server closed")
+				return
+			}
+			logrus.Errorf("Metrics (http) serving failed: %v", err)
+		}
+	}()
+
+	return nil
+}
+
+// registerMetrics registers plain provisioner prometheus metrics.
+func registerMetrics() error {
+	// Register all of the metrics in the standard registry.
+	prometheus.MustRegister(bundleGaugeVec)
+	return nil
+}
+
+type BundleMetricsRecorder struct {
+	bundle *rukpakv1alpha1.Bundle
+	logger logr.Logger
+}
+
+func NewBundleMetricsRecorder(b *rukpakv1alpha1.Bundle, l logr.Logger) BundleMetricsRecorder {
+	return BundleMetricsRecorder{b, l}
+}
+
+func (r *BundleMetricsRecorder) SetBundleMetric() {
+	switch r.bundle.Status.Phase {
+	case string(rukpakv1alpha1.PhaseUnpacked):
+		r.logger.V(1).Info(fmt.Sprintf("Setting bundle{%s,%s} metric to 1", r.bundle.Name, r.bundle.Namespace))
+		bundleGaugeVec.WithLabelValues(r.bundle.Name, r.bundle.Namespace).Set(1)
+	case string(rukpakv1alpha1.PhaseFailing):
+		r.logger.V(1).Info(fmt.Sprintf("Setting bundle{%s,%s} metric to -1", r.bundle.Name, r.bundle.Namespace))
+		bundleGaugeVec.WithLabelValues(r.bundle.Name, r.bundle.Namespace).Set(-1)
+	default:
+		r.logger.V(1).Info(fmt.Sprintf("Setting bundle{%s,%s} metric to 0", r.bundle.Name, r.bundle.Namespace))
+		bundleGaugeVec.WithLabelValues(r.bundle.Name, r.bundle.Namespace).Set(0)
+	}
+}
+
+func (r *BundleMetricsRecorder) DeleteBundleMetric() {
+	r.logger.V(1).Info(fmt.Sprintf("Deleting bundle{%s,%s} metric", r.bundle.Name, r.bundle.Namespace))
+	bundleGaugeVec.DeleteLabelValues(r.bundle.Name, r.bundle.Namespace)
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -114,12 +114,12 @@ func SetBundleInfo(info *rukpakv1alpha1.BundleInfo) UpdateStatusFunc {
 	}
 }
 
-func SetPhase(phase string) UpdateStatusFunc {
+func SetPhase(phase rukpakv1alpha1.BundlePhase) UpdateStatusFunc {
 	return func(status *rukpakv1alpha1.BundleStatus) bool {
-		if status.Phase == phase {
+		if status.Phase == string(phase) {
 			return false
 		}
-		status.Phase = phase
+		status.Phase = string(phase)
 		return true
 	}
 }

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Updater", func() {
 		obj    *rukpakv1alpha1.Bundle
 		status = &rukpakv1alpha1.BundleStatus{
 			Info:               &rukpakv1alpha1.BundleInfo{},
-			Phase:              rukpakv1alpha1.PhaseFailing,
+			Phase:              string(rukpakv1alpha1.PhaseFailing),
 			Digest:             "digest",
 			ObservedGeneration: 1,
 			Conditions: []metav1.Condition{
@@ -77,7 +77,7 @@ var _ = Describe("Updater", func() {
 			},
 			Status: rukpakv1alpha1.BundleStatus{
 				Info:               &rukpakv1alpha1.BundleInfo{},
-				Phase:              rukpakv1alpha1.PhaseFailing,
+				Phase:              string(rukpakv1alpha1.PhaseFailing),
 				Digest:             "digest",
 				ObservedGeneration: 1,
 				Conditions: []metav1.Condition{
@@ -106,7 +106,7 @@ var _ = Describe("Updater", func() {
 	When("the object does not exist", func() {
 		It("should fail", func() {
 			Expect(client.Delete(context.Background(), obj)).To(Succeed())
-			u.UpdateStatus(updater.EnsureCondition(status.Conditions[0]), updater.EnsureObservedGeneration(status.ObservedGeneration), updater.EnsureBundleDigest(status.Digest), updater.SetBundleInfo(status.Info), updater.SetPhase(status.Phase))
+			u.UpdateStatus(updater.EnsureCondition(status.Conditions[0]), updater.EnsureObservedGeneration(status.ObservedGeneration), updater.EnsureBundleDigest(status.Digest), updater.SetBundleInfo(status.Info), updater.SetPhase(rukpakv1alpha1.BundlePhase(status.Phase)))
 			err := u.Apply(context.Background(), obj)
 			Expect(err).NotTo(BeNil())
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())

--- a/manifests/provisioners/plain/kustomization.yaml
+++ b/manifests/provisioners/plain/kustomization.yaml
@@ -3,3 +3,4 @@ resources:
   - resources/cluster_role.yaml
   - resources/cluster_role_binding.yaml
   - resources/deployment.yaml
+  - resources/service.yaml

--- a/manifests/provisioners/plain/resources/deployment.yaml
+++ b/manifests/provisioners/plain/resources/deployment.yaml
@@ -22,3 +22,6 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
+            - containerPort: 8383
+              name: metrics
+              protocol: TCP

--- a/manifests/provisioners/plain/resources/service.yaml
+++ b/manifests/provisioners/plain/resources/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: plain-provisioner-metrics
+  namespace: rukpak-system
+spec:
+  selector:
+    app: plain-provisioner
+  ports:
+  - name: metrics
+    port: 8383
+    protocol: TCP
+    targetPort: 8383

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -11,12 +11,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
-	c client.Client
+	c             client.Client
+	coreClientSet *kubernetes.Clientset
 )
 
 func TestE2E(t *testing.T) {
@@ -43,5 +45,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).To(BeNil())
 
 	c, err = client.New(config, client.Options{Scheme: scheme})
+	Expect(err).To(BeNil())
+
+	coreClientSet, err = kubernetes.NewForConfig(config)
 	Expect(err).To(BeNil())
 })

--- a/test/e2e/like_metric_matcher_test.go
+++ b/test/e2e/like_metric_matcher_test.go
@@ -1,0 +1,114 @@
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+)
+
+type Metric struct {
+	Family string
+	Labels map[string][]string
+	Value  float64 // Zero unless type is Untypted, Gauge, or Counter!
+}
+
+type MetricPredicate struct {
+	f    func(m Metric) bool
+	name string
+}
+
+func (mp MetricPredicate) String() string {
+	return mp.name
+}
+
+func WithFamily(f string) MetricPredicate {
+	return MetricPredicate{
+		name: fmt.Sprintf("WithFamily(%s)", f),
+		f: func(m Metric) bool {
+			return m.Family == f
+		},
+	}
+}
+
+func WithLabel(n, v string) MetricPredicate {
+	return MetricPredicate{
+		name: fmt.Sprintf("WithLabel(%s=%s)", n, v),
+		f: func(m Metric) bool {
+			for name, values := range m.Labels {
+				for _, value := range values {
+					if name == n && value == v {
+						return true
+					}
+				}
+			}
+			return false
+		},
+	}
+}
+
+func WithName(name string) MetricPredicate {
+	return WithLabel("Name", name)
+}
+
+func WithNamespace(namespace string) MetricPredicate {
+	return WithLabel("Namespace", namespace)
+}
+
+func WithValue(v float64) MetricPredicate {
+	return MetricPredicate{
+		name: fmt.Sprintf("WithValue(%g)", v),
+		f: func(m Metric) bool {
+			return m.Value == v
+		},
+	}
+}
+
+func WithValueGreaterThan(v float64) MetricPredicate {
+	return MetricPredicate{
+		name: fmt.Sprintf("WithValueGreaterThan(%g)", v),
+		f: func(m Metric) bool {
+			return m.Value > v
+		},
+	}
+}
+
+func WithValueLessThan(v float64) MetricPredicate {
+	return MetricPredicate{
+		name: fmt.Sprintf("WithValueGreaterThan(%g)", v),
+		f: func(m Metric) bool {
+			return m.Value < v
+		},
+	}
+}
+
+type LikeMetricMatcher struct {
+	Predicates []MetricPredicate
+}
+
+func (matcher *LikeMetricMatcher) Match(actual interface{}) (bool, error) {
+	metric, ok := actual.(Metric)
+	if !ok {
+		return false, fmt.Errorf("LikeMetric matcher expects Metric (got %T)", actual)
+	}
+	for _, predicate := range matcher.Predicates {
+		if !predicate.f(metric) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (matcher *LikeMetricMatcher) FailureMessage(actual interface{}) string {
+	return format.Message(actual, "to satisfy", matcher.Predicates)
+}
+
+func (matcher *LikeMetricMatcher) NegatedFailureMessage(actual interface{}) string {
+	return format.Message(actual, "not to satisfy", matcher.Predicates)
+}
+
+func LikeMetric(preds ...MetricPredicate) types.GomegaMatcher {
+	return &LikeMetricMatcher{
+		Predicates: preds,
+	}
+}

--- a/test/e2e/plain_provisioner_test.go
+++ b/test/e2e/plain_provisioner_test.go
@@ -240,10 +240,10 @@ var _ = Describe("plain provisioner bundle", func() {
 				if err != nil {
 					return false
 				}
-				if bundle.Status.Phase != rukpakv1alpha1.PhasePending {
+				if bundle.Status.Phase != string(rukpakv1alpha1.PhasePending) {
 					return false
 				}
-				unpackPending := meta.FindStatusCondition(bundle.Status.Conditions, rukpakv1alpha1.PhaseUnpacked)
+				unpackPending := meta.FindStatusCondition(bundle.Status.Conditions, string(rukpakv1alpha1.PhaseUnpacked))
 				if unpackPending == nil {
 					return false
 				}
@@ -398,7 +398,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					if err := c.Get(ctx, client.ObjectKeyFromObject(bundle), bundle); err != nil {
 						return false
 					}
-					if bundle.Status.Phase != rukpakv1alpha1.PhaseUnpacked {
+					if bundle.Status.Phase != string(rukpakv1alpha1.PhaseUnpacked) {
 						return false
 					}
 					if bundle.Status.Info == nil {
@@ -455,7 +455,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					if err := c.Get(ctx, client.ObjectKeyFromObject(bundle), bundle); err != nil {
 						return false
 					}
-					if bundle.Status.Phase != rukpakv1alpha1.PhaseUnpacked {
+					if bundle.Status.Phase != string(rukpakv1alpha1.PhaseUnpacked) {
 						return false
 					}
 					if bundle.Status.Info == nil {
@@ -512,7 +512,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					if err := c.Get(ctx, client.ObjectKeyFromObject(bundle), bundle); err != nil {
 						return false
 					}
-					if bundle.Status.Phase != rukpakv1alpha1.PhaseUnpacked {
+					if bundle.Status.Phase != string(rukpakv1alpha1.PhaseUnpacked) {
 						return false
 					}
 					if bundle.Status.Info == nil {
@@ -570,7 +570,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					if err := c.Get(ctx, client.ObjectKeyFromObject(bundle), bundle); err != nil {
 						return false
 					}
-					if bundle.Status.Phase != rukpakv1alpha1.PhaseUnpacked {
+					if bundle.Status.Phase != string(rukpakv1alpha1.PhaseUnpacked) {
 						return false
 					}
 					if bundle.Status.Info == nil {

--- a/test/e2e/utils_test.go
+++ b/test/e2e/utils_test.go
@@ -1,0 +1,101 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"strconv"
+	"strings"
+
+	. "github.com/onsi/gomega"
+	promClient "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/kubernetes"
+)
+
+func conditionsSemanticallyEqual(a, b metav1.Condition) bool {
+	return a.Type == b.Type && a.Status == b.Status && a.Reason == b.Reason && a.Message == b.Message
+}
+
+func conditionsLooselyEqual(a, b metav1.Condition) bool {
+	return a.Type == b.Type && a.Status == b.Status && a.Reason == b.Reason && strings.Contains(b.Message, a.Message)
+}
+
+func extractMetricPortFromPod(pod *corev1.Pod) string {
+	for _, container := range pod.Spec.Containers {
+		for _, port := range container.Ports {
+			if port.Name == "metrics" {
+				return strconv.Itoa(int(port.ContainerPort))
+			}
+		}
+	}
+	return "-1"
+}
+
+func getMetricsFromPod(client *kubernetes.Clientset, pod *corev1.Pod) []Metric {
+	mfs := make(map[string]*promClient.MetricFamily)
+	EventuallyWithOffset(1, func() error {
+		raw, err := client.CoreV1().RESTClient().Get().
+			Namespace(pod.GetNamespace()).
+			Resource("pods").
+			SubResource("proxy").
+			Name(net.JoinSchemeNamePort("", pod.GetName(), extractMetricPortFromPod(pod))).
+			Suffix("metrics").
+			Do(context.Background()).Raw()
+		if err != nil {
+			return err
+		}
+		var p expfmt.TextParser
+		mfs, err = p.TextToMetricFamilies(bytes.NewReader(raw))
+		if err != nil {
+			return err
+		}
+		return nil
+	}).Should(Succeed())
+
+	var metrics []Metric
+	for family, mf := range mfs {
+		if strings.HasPrefix(family, "go_") || strings.HasPrefix(family, "process_") || strings.HasPrefix(family, "promhttp_") {
+			continue
+		}
+		for _, metric := range mf.Metric {
+			m := Metric{
+				Family: family,
+			}
+			if len(metric.GetLabel()) > 0 {
+				m.Labels = make(map[string][]string)
+			}
+			for _, pair := range metric.GetLabel() {
+				m.Labels[pair.GetName()] = append(m.Labels[pair.GetName()], pair.GetValue())
+			}
+			if u := metric.GetUntyped(); u != nil {
+				m.Value = u.GetValue()
+			}
+			if g := metric.GetGauge(); g != nil {
+				m.Value = g.GetValue()
+			}
+			if c := metric.GetCounter(); c != nil {
+				m.Value = c.GetValue()
+			}
+			metrics = append(metrics, m)
+		}
+	}
+	return metrics
+}
+
+func getPodWithLabel(client *kubernetes.Clientset, label string) *corev1.Pod {
+	listOptions := metav1.ListOptions{LabelSelector: label}
+	var podList *corev1.PodList
+	EventuallyWithOffset(1, func() (numPods int, err error) {
+		podList, err = client.CoreV1().Pods(defaultSystemNamespace).List(context.Background(), listOptions)
+		if podList != nil {
+			numPods = len(podList.Items)
+		}
+
+		return
+	}).Should(Equal(1), "number of pods never scaled to one")
+
+	return &podList.Items[0]
+}


### PR DESCRIPTION
Note: This PR only introduces a gauge vector metric emitted from the bundle controller. 
Holding off on introducing metrics from the bundleInstance controller until [this is resovled](https://github.com/operator-framework/rukpak/blob/main/internal/provisioner/plain/controllers/bundleinstance_controller.go#L79-L82):
```
// TODO(user): Modify the Reconcile function to compare the state specified by
// the BundleInstance object against the actual cluster state, and then
// perform operations to make the cluster state reflect the state specified by
// the user.
```

Closes #266