### PR TITLE
.github: Fix the release workflow automation on tag event triggers

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
           # Release tags.
           echo IMAGE_TAG="${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
           echo GORELEASER_ARGS="--rm-dist" >> $GITHUB_ENV
-          echo DISABLE_RELEASE_PIPELINE=true >> $GITHUB_ENV
+          echo DISABLE_RELEASE_PIPELINE=false >> $GITHUB_ENV
         elif [[ $GITHUB_REF == refs/heads/* ]]; then
           # Branch build.
           echo IMAGE_TAG="$(echo "${GITHUB_REF#refs/heads/}" | sed -r 's|/+|-|g')" >> $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ kind-cluster: ## Standup a kind cluster for e2e testing usage
 install-apis: generate kustomize ## Install the core rukpak CRDs
 	$(KUSTOMIZE) build manifests/apis/crds | kubectl apply -f -
 
-install-provisioners: kustomize ## Install the plain provisioner
+install-provisioners: kustomize ## Install the rukpak provisioners
 	$(KUSTOMIZE) build manifests/provisioners | kubectl apply -f -
 
 install-crdvalidator-webhook: kustomize ## Install the crdvalidator webhook to the current cluster.


### PR DESCRIPTION
#187 broke the release workflow where automation was responsible for creating a new github release when a new tag was pushed to this repository.

Closes #261 