### PR TITLE
Optional CRD Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,11 @@ a `spec.provisionerClassName` that matches that particular ID.
 For example, in this repository the [plain](internal/provisioner/plain/README.md) provisioner is implemented.
 The `plain` provisioner is able to unpack a given `plain+v0` bundle onto a cluster and then instantiate it, making
 the content of the bundle available in the cluster.
+
+### CustomResourceDefinition (CRD) Validator
+
+RukPak comes with a webhook for validating the upgrade of CRDs from `Bundle`s. If a CRD does potentially destructive
+actions to the cluster, it will not allow it go be applied. In the context of RukPak, this will result in a failed 
+`BundleInstance` resolution. 
+
+To read more about this webhook, and learn how to disable this default behavior, view the `crdvalidator` [documentation](cmd/crdvalidator/README.md).

--- a/cmd/crdvalidator/README.md
+++ b/cmd/crdvalidator/README.md
@@ -1,0 +1,106 @@
+# crdvalidator
+
+## Summary
+A part of the core value proposition for RukPak is the safe upgrade of a [CustomResourceDefinition](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/) (`CRD`). As a result, this repository comes equipped with a "CRD Validator Webhook" (`crdvalidator`), that will validate all `CRD` upgrades created by RukPak. This protects your `BundleInstance` pivots from having potentially dangerous effects such as data loss. 
+
+### How to use
+
+`crdvalidator` will ensure that any `CRD` upgrade is safe as long as the CRD is associated with RukPak. If you would like to disable validation for a `CRD` included in a specific `Bundle`, you will need to explicitly set the `core.rukpak.io/safe-crd-upgrade-validation` annotation to `false` within that specific CRD's manifest.
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    core.rukpak.io/safe-crd-upgrade-validation: false # <--
+```
+
+### What is protected
+There are three main cases `crdvalidator` is checking against with every specified `CRD` upgrade. These are where a new `CRD`:
+1. Removes a stored version and ensures that removing the stored version does not result in data loss.
+2. Changes a version that old `CRD` had and it must validate existing CRs against the new schema.
+3. Adds a version that old `CRD` does not have. In this case `crdvalidator` checks if the conversion strategy is:
+    - None, then ensures that existing CRs validate with new schema.
+    - Webhook, then allow update (assuming webhook handles conversion correctly)
+
+#### Update the schema that invalidates existing CRs
+Say that you have installed a `CRD` onto the cluster with a Kind of `Sample` that has a single property of `examplearray`. 
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+    core.rukpak.io/safe-upgrade-validation: enabled
+  creationTimestamp: null
+  name: sample.example.io
+#
+# ...
+#
+spec:
+    versions:
+    - name: v1alpha1
+        schema:
+        openAPIV3Schema:
+            properties:
+                exampleProperty:
+                    description: exampleProperty is a string property to demonstrate crd validation logic.
+                    type: string
+```
+
+With this installed onto the cluster, you go ahead and create a `CR` of a `Sample` onto the cluster. 
+
+```yaml
+apiVersion: sample.example.io
+kind: Sample
+metadata:
+    name: sampleResource
+```
+
+If you then update that `CRD`'s schema in such a way that the `CR` you just created was invalidated, like so:
+
+```yaml
+#
+# ...
+#
+spec:
+    versions:
+    - name: v1alpha1
+        schema:
+        openAPIV3Schema:
+            type: string
+            required: # Updating the exampleProperty to be required
+                - exampleProperty
+            properties:
+                exampleProperty:
+                    description: exampleProperty is an array of strings to demonstrate crd validation logic.
+                    type: string
+```
+
+
+`crdvalidator` will prevent the update from occurring with the following error. This is because the existing `CR` does not have a value set for the required field of `exampleProperty`.
+
+```
+admission webhook "webhook.crdvalidator.io" denied the request: failed to validate safety of UPDATE for CRD "sample.example.io" (NOTE: to disable this validation, set the "core.rukpak.io/safe-crd-upgrade-validation" annotation to "false"): error validating existing CRs against new CRD's schema for "sample.example.io": existing custom object /sampleResource failed validation for new schema version v1alpha1: [].exampleProperty: Required value
+```
+
+## Running locally
+
+`crdvalidator` is included with every default installation of RukPak. To run this locally, simply run the make target with a kind cluster started.
+
+```console
+make run
+```
+
+By default, `crdvalidator`'s test suite runs alongside RukPak's, but you can also just run `crdvalidator`'s specific tests.
+
+```console
+make e2e TEST="crdvalidator"
+```
+
+If you would like to install the `crdvalidator` onto your current cluster without RukPak, you'll need to install `cert-mgr` and then `crdvalidator`
+
+```console
+make cert-mgr install-crdvalidator-webhook
+```

--- a/cmd/crdvalidator/annotation/annotation.go
+++ b/cmd/crdvalidator/annotation/annotation.go
@@ -1,0 +1,6 @@
+package annotation
+
+const (
+	ValidationKey = "core.rukpak.io/safe-crd-upgrade-validation"
+	Disabled      = "false"
+)

--- a/manifests/crdvalidator/04_webhook.yaml
+++ b/manifests/crdvalidator/04_webhook.yaml
@@ -18,6 +18,9 @@ webhooks:
         name: crd-validation-webhook
         path: /validate-crd
         port: 9443
+    objectSelector:
+      matchLabels:
+        core.rukpak.io/owner-kind: BundleInstance
     admissionReviewVersions: ["v1"]
     sideEffects: None
 ---

--- a/test/e2e/crdvalidator_test.go
+++ b/test/e2e/crdvalidator_test.go
@@ -2,15 +2,20 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/operator-framework/rukpak/cmd/crdvalidator/annotation"
+	"github.com/operator-framework/rukpak/internal/util"
 	"github.com/operator-framework/rukpak/test/testutil"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 )
 
-var _ = Describe("crd validation webhook", func() {
+var _ = Describe("crdvalidator", func() {
 	When("a crd event is emitted", func() {
 		var ctx context.Context
 
@@ -47,7 +52,7 @@ var _ = Describe("crd validation webhook", func() {
 				Expect(c.Delete(ctx, crd)).To(BeNil())
 			})
 
-			It("should allow the crd update event to occur", func() {
+			It("should allow the crd update event to occur without being owned by RukPak", func() {
 				Eventually(func() error {
 					if err := c.Get(ctx, client.ObjectKeyFromObject(crd), crd); err != nil {
 						return err
@@ -66,6 +71,125 @@ var _ = Describe("crd validation webhook", func() {
 							},
 						},
 					})
+
+					return c.Update(ctx, crd)
+				}).Should(Succeed())
+			})
+
+			It("should allow the crd update event to occur being owned by RukPak", func() {
+				Eventually(func() error {
+					if err := c.Get(ctx, client.ObjectKeyFromObject(crd), crd); err != nil {
+						return err
+					}
+
+					crd.Spec.Versions[0].Storage = false
+
+					crd.Spec.Versions = append(crd.Spec.Versions, apiextensionsv1.CustomResourceDefinitionVersion{
+						Name:    "v1alpha2",
+						Served:  true,
+						Storage: true,
+						Schema: &apiextensionsv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+								Type:        "object",
+								Description: "my crd schema",
+							},
+						},
+					})
+
+					crd.Labels = map[string]string{util.CoreOwnerKindKey: rukpakv1alpha1.BundleInstanceKind}
+
+					return c.Update(ctx, crd)
+				}).Should(Succeed())
+			})
+		})
+
+		When("an incoming crd event modifies the schema in a way that breaks an existing cr", func() {
+			var crd *apiextensionsv1.CustomResourceDefinition
+
+			BeforeEach(func() {
+				crd = testutil.NewTestingCRD("", testutil.DefaultGroup,
+					[]apiextensionsv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha1",
+						Served:  true,
+						Storage: true,
+						Schema: &apiextensionsv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+								Type:        "object",
+								Description: "my crd schema",
+								Properties: map[string]apiextensionsv1.JSONSchemaProps{
+									"sampleProperty": {Type: "string"},
+								},
+							},
+						},
+					}},
+				)
+
+				crd.Labels = map[string]string{util.CoreOwnerKindKey: rukpakv1alpha1.BundleInstanceKind}
+
+				Eventually(func() error {
+					return c.Create(ctx, crd)
+				}).Should(Succeed(), "should be able to create a safe crd but was not")
+
+				// Build up a CR to create out of unstructured.Unstructured
+				sampleCR := testutil.NewTestingCR(testutil.DefaultCrName, testutil.DefaultGroup, "v1alpha1", crd.Spec.Names.Singular)
+				Eventually(func() error {
+					return c.Create(ctx, sampleCR)
+				}).Should(Succeed(), "should be able to create a cr for the sample crd but was not")
+
+			})
+
+			AfterEach(func() {
+				By("deleting the testing crd")
+				Expect(c.Delete(ctx, crd)).To(BeNil())
+			})
+
+			It("should be invalidated if owned by RukPak", func() {
+				Eventually(func() string {
+					if err := c.Get(ctx, client.ObjectKeyFromObject(crd), crd); err != nil {
+						return err.Error()
+					}
+
+					// Update the v1alpha1 schema to invalidate existing CR created in BeforeEach()
+					crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Required = []string{"sampleProperty"}
+
+					err := c.Update(ctx, crd)
+					fmt.Println(err)
+					if err != nil {
+						return err.Error()
+					}
+					return ""
+				}).Should(ContainSubstring("error validating existing CRs against new CRD's schema"))
+			})
+
+			It("should be admitted if not owned by RukPak", func() {
+				Eventually(func() error {
+					if err := c.Get(ctx, client.ObjectKeyFromObject(crd), crd); err != nil {
+						return err
+					}
+
+					// Remove the "core.rukpak.io/owner-kind" label
+					crd.Labels = map[string]string{}
+					Expect(c.Update(ctx, crd)).To(BeNil())
+
+					// Update the v1alpha1 schema to invalidate existing CR created in BeforeEach()
+					crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Required = []string{"sampleProperty"}
+
+					return c.Update(ctx, crd)
+				}).Should(Succeed())
+			})
+
+			It("should be admitted if owned by RukPak but disabled explicitly by annotation", func() {
+				Eventually(func() error {
+					if err := c.Get(ctx, client.ObjectKeyFromObject(crd), crd); err != nil {
+						return err
+					}
+
+					// Add the "core.rukpak.io/safe-upgrade-validation" label set to "disabled"
+					crd.Annotations = map[string]string{annotation.ValidationKey: annotation.Disabled}
+					Expect(c.Update(ctx, crd)).To(BeNil())
+
+					// Update the v1alpha1 schema to invalidate existing CR created in BeforeEach()
+					crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Required = []string{"sampleProperty"}
 
 					return c.Update(ctx, crd)
 				}).Should(Succeed())
@@ -164,61 +288,6 @@ var _ = Describe("crd validation webhook", func() {
 					}
 					return ""
 				}).Should(ContainSubstring("cannot remove stored versions"))
-			})
-		})
-
-		When("an incoming crd event modifies the schema in a way that breaks an existing cr", func() {
-			var crd *apiextensionsv1.CustomResourceDefinition
-
-			BeforeEach(func() {
-				crd = testutil.NewTestingCRD("", testutil.DefaultGroup, []apiextensionsv1.CustomResourceDefinitionVersion{{
-					Name:    "v1alpha1",
-					Served:  true,
-					Storage: true,
-					Schema: &apiextensionsv1.CustomResourceValidation{
-						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
-							Type:        "object",
-							Description: "my crd schema",
-							Properties: map[string]apiextensionsv1.JSONSchemaProps{
-								"sampleProperty": {Type: "string"},
-							},
-						},
-					},
-				}},
-				)
-
-				Eventually(func() error {
-					return c.Create(ctx, crd)
-				}).Should(Succeed(), "should be able to create a safe crd but was not")
-
-				// Build up a CR to create out of unstructured.Unstructured
-				sampleCR := testutil.NewTestingCR(testutil.DefaultCrName, testutil.DefaultGroup, "v1alpha1", crd.Spec.Names.Singular)
-				Eventually(func() error {
-					return c.Create(ctx, sampleCR)
-				}).Should(Succeed(), "should be able to create a cr for the sample crd but was not")
-
-			})
-
-			AfterEach(func() {
-				By("deleting the testing crd")
-				Expect(c.Delete(ctx, crd)).To(BeNil())
-			})
-
-			It("should deny admission", func() {
-				Eventually(func() string {
-					if err := c.Get(ctx, client.ObjectKeyFromObject(crd), crd); err != nil {
-						return err.Error()
-					}
-
-					// Update the v1alpha1 schema to invalidate existing CR created in BeforeEach()
-					crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Required = []string{"sampleProperty"}
-
-					err := c.Update(ctx, crd)
-					if err != nil {
-						return err.Error()
-					}
-					return ""
-				}).Should(ContainSubstring("error validating existing CRs against new CRD's schema"))
 			})
 		})
 	})


### PR DESCRIPTION
The intent of this PR is to give an opt-out approach for the `crdvalidator` which only runs against RukPak provisioned CRDs. `crdvalidator` will now check the `Labels` of an incoming CRD event for `core.rukpak.io/owner-kind` to determine if it is being created by RukPak and thus run the validation logic. To turn this off for a specific CRD made by RukPak, the following annotation needs to be set for the CRD within the `Bundle`:

```yaml
core.rukpak.io/safe-upgrade-validation: disabled
```

Closes #245 
Closes #259 