### PR TITLE
*: Avoid hardcoding the Bundle and BI metadata.Kind(s)

### DIFF
--- a/api/v1alpha1/bundle_types.go
+++ b/api/v1alpha1/bundle_types.go
@@ -20,6 +20,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var (
+	BundleGVK  = SchemeBuilder.GroupVersion.WithKind("Bundle")
+	BundleKind = BundleGVK.Kind
+)
+
 type BundleConditionType string
 
 const (

--- a/api/v1alpha1/bundleinstance_types.go
+++ b/api/v1alpha1/bundleinstance_types.go
@@ -20,8 +20,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+var (
+	BundleInstanceGVK  = SchemeBuilder.GroupVersion.WithKind("BundleInstance")
+	BundleInstanceKind = BundleInstanceGVK.Kind
+)
 
 const (
 	TypeHasValidBundle       = "HasValidBundle"

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -74,7 +74,7 @@ func main() {
 	setupLog.Info("starting up the rukpak core webhook", "Git commit", version.String())
 
 	cfg := ctrl.GetConfigOrDie()
-	dependentRequirement, err := labels.NewRequirement("api.core.rukpak.io/owner-kind", selection.In, []string{"Bundle"})
+	dependentRequirement, err := labels.NewRequirement("api.core.rukpak.io/owner-kind", selection.In, []string{rukpakv1alpha1.BundleKind})
 	if err != nil {
 		setupLog.Error(err, "unable to create dependent label selector for cache")
 		os.Exit(1)
@@ -102,7 +102,7 @@ func main() {
 	}
 
 	if err = (&rukpakv1alpha1.Bundle{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "Bundle")
+		setupLog.Error(err, "unable to create webhook", "webhook", rukpakv1alpha1.BundleKind)
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder

--- a/internal/provisioner/plain/controllers/bundleinstance_controller.go
+++ b/internal/provisioner/plain/controllers/bundleinstance_controller.go
@@ -333,7 +333,7 @@ func (r *BundleInstanceReconciler) loadBundle(ctx context.Context, bi *rukpakv1a
 	for _, obj := range objects {
 		obj := obj
 		obj.SetLabels(util.MergeMaps(obj.GetLabels(), map[string]string{
-			"core.rukpak.io/owner-kind": "BundleInstance",
+			"core.rukpak.io/owner-kind": rukpakv1alpha1.BundleInstanceKind,
 			"core.rukpak.io/owner-name": bi.Name,
 		}))
 		objs = append(objs, &obj)

--- a/internal/provisioner/plain/main.go
+++ b/internal/provisioner/plain/main.go
@@ -90,7 +90,7 @@ func main() {
 		setupLog.Error(err, "unable to create kubernetes client")
 		os.Exit(1)
 	}
-	dependentRequirement, err := labels.NewRequirement("core.rukpak.io/owner-kind", selection.In, []string{"Bundle", "BundleInstance"})
+	dependentRequirement, err := labels.NewRequirement("core.rukpak.io/owner-kind", selection.In, []string{rukpakv1alpha1.BundleKind, rukpakv1alpha1.BundleInstanceKind})
 	if err != nil {
 		setupLog.Error(err, "unable to create dependent label selector for cache")
 		os.Exit(1)
@@ -134,7 +134,7 @@ func main() {
 		UnpackImage:    unpackImage,
 		GitClientImage: gitClientImage,
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Bundle")
+		setupLog.Error(err, "unable to create controller", "controller", rukpakv1alpha1.BundleKind)
 		os.Exit(1)
 	}
 
@@ -146,7 +146,7 @@ func main() {
 		ReleaseNamespace:   ns,
 		ActionClientGetter: helmclient.NewActionClientGetter(cfgGetter),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "BundleInstance")
+		setupLog.Error(err, "unable to create controller", "controller", rukpakv1alpha1.BundleInstanceKind)
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -96,13 +96,13 @@ func newLabelSelector(name, kind string) labels.Selector {
 // NewBundleLabelSelector is responsible for constructing a label.Selector
 // for any underlying resources that are associated with the Bundle parameter.
 func NewBundleLabelSelector(bundle *rukpakv1alpha1.Bundle) labels.Selector {
-	return newLabelSelector(bundle.GetName(), "Bundle")
+	return newLabelSelector(bundle.GetName(), rukpakv1alpha1.BundleKind)
 }
 
 // NewBundleInstanceLabelSelector is responsible for constructing a label.Selector
 // for any underlying resources that are associated with the BundleInstance parameter.
 func NewBundleInstanceLabelSelector(bi *rukpakv1alpha1.BundleInstance) labels.Selector {
-	return newLabelSelector(bi.GetName(), "BundleInstance")
+	return newLabelSelector(bi.GetName(), rukpakv1alpha1.BundleInstanceKind)
 }
 
 func CreateOrRecreate(ctx context.Context, cl client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {


### PR DESCRIPTION
Goal: quick cleanup PR that adds a global variable for the Bundle/BI GVK/Kind values so the repository can reference those values, and avoid hardcoding the string metadata.Kind values.

Signed-off-by: timflannagan <timflannagan@gmail.com>