### PR TITLE
Generalize bundle image printcolumn

### DIFF
--- a/api/v1alpha1/bundle_types.go
+++ b/api/v1alpha1/bundle_types.go
@@ -121,7 +121,7 @@ type BundleObject struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:resource:scope=Cluster
 //+kubebuilder:subresource:status
-//+kubebuilder:printcolumn:name=Image,type=string,JSONPath=`.spec.source.image.ref`
+//+kubebuilder:printcolumn:name=Reference,type=string,JSONPath=`.spec.source.image.ref`,priority=1
 //+kubebuilder:printcolumn:name=Type,type=string,JSONPath=`.spec.source.type`
 //+kubebuilder:printcolumn:name=Phase,type=string,JSONPath=`.status.phase`
 //+kubebuilder:printcolumn:name=Age,type=date,JSONPath=`.metadata.creationTimestamp`

--- a/manifests/apis/crds/core.rukpak.io_bundles.yaml
+++ b/manifests/apis/crds/core.rukpak.io_bundles.yaml
@@ -18,7 +18,8 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .spec.source.image.ref
-      name: Image
+      name: Reference
+      priority: 1
       type: string
     - jsonPath: .spec.source.type
       name: Type


### PR DESCRIPTION
This PR is a bandaid solution to #163 which renames the displayed field from `Image` to `Reference` and moves it behind the `-o wide` output. It does not successfully display an arbitrary reference to an image or git repository, as JSONPath does not support conditional statements and there is no singular field to reference. Potentially once #164 merges there can be a follow-up that links `Reference` to a well-defined field on the Bundle status. 

Closes #163 
There will be a follow-up issue to move the displayed field back to the default output, instead of under `-o wide`.  