### PR TITLE
add image pull secret suport for image bundle

### DIFF
--- a/api/v1alpha1/bundle_types.go
+++ b/api/v1alpha1/bundle_types.go
@@ -64,6 +64,8 @@ type BundleSource struct {
 type ImageSource struct {
 	// Ref contains the reference to a container image containing Bundle contents.
 	Ref string `json:"ref"`
+	// ImagePullSecretName contains the name of the image pull secret in the namespace that the provisioner is deployed.
+	ImagePullSecretName string `json:"pullSecret,omitempty"`
 }
 
 type GitSource struct {

--- a/internal/provisioner/plain/controllers/bundle_controller.go
+++ b/internal/provisioner/plain/controllers/bundle_controller.go
@@ -406,6 +406,9 @@ func bundleImagePod(pod *corev1.Pod, source rukpakv1alpha1.ImageSource, unpackIm
 	pod.Spec.Containers[0].Command = []string{"/bin/unpack", "--bundle-dir", "/"}
 	pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{Name: "util", MountPath: "/bin"}}
 
+	if source.ImagePullSecretName != "" {
+		pod.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: source.ImagePullSecretName}}
+	}
 	pod.Spec.Volumes = []corev1.Volume{
 		{Name: "util", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
 	}

--- a/manifests/apis/crds/core.rukpak.io_bundles.yaml
+++ b/manifests/apis/crds/core.rukpak.io_bundles.yaml
@@ -101,6 +101,11 @@ spec:
                     description: Image is the bundle image that backs the content
                       of this bundle.
                     properties:
+                      pullSecret:
+                        description: ImagePullSecretName contains the name of the
+                          image pull secret in the namespace that the provisioner
+                          is deployed.
+                        type: string
                       ref:
                         description: Ref contains the reference to a container image
                           containing Bundle contents.


### PR DESCRIPTION
Signed-off-by: akihikokuroda <akuroda@us.ibm.com>

An optional `ImagePullSecretName` is added in the `ImageSource`.

Closes: #81 