### PR TITLE
add private git source support

### DIFF
--- a/api/v1alpha1/bundle_types.go
+++ b/api/v1alpha1/bundle_types.go
@@ -81,6 +81,11 @@ type GitSource struct {
 	// is required. Setting more than one field or zero fields will result in an
 	// error.
 	Ref GitRef `json:"ref"`
+	// SecretName contains the secret name that has authorization information for HTTPS protocol and is in the namespace that the provisioner is deployed.
+	// The secret is expected to contain `data.username` and `data.accesstoken` for the username and personal access token, respectively.
+	SecretName string `json:"secretName,omitempty"`
+	// If SslNoVerify is set true, the server certificate is ignored.
+	SslNoVerify bool `json:"sslNoVerify,omitempty"`
 }
 
 type GitRef struct {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -86,6 +86,31 @@ func TestCheckoutCommand(t *testing.T) {
 			expected: "",
 			err:      errors.New("cannot specify both branch and commit: only one is allowed"),
 		},
+		{
+			source: rukpakv1alpha1.GitSource{
+				Repository: "https://github.com/operator-framework/combo",
+				Ref: rukpakv1alpha1.GitRef{
+					Commit: "4567031e158b42263e70a7c63e29f8981a4a6135",
+				},
+				SecretName: "secretname",
+			},
+			expected: fmt.Sprintf("git clone %s %s && cd %s && git checkout %s && rm -r .git && cp -r %s/. /bundle",
+				"https://$USER:$TOKEN@github.com/operator-framework/combo", repositoryName, repositoryName, "4567031e158b42263e70a7c63e29f8981a4a6135",
+				"./"),
+		},
+		{
+			source: rukpakv1alpha1.GitSource{
+				Repository: "https://github.com/operator-framework/combo",
+				Ref: rukpakv1alpha1.GitRef{
+					Commit: "4567031e158b42263e70a7c63e29f8981a4a6135",
+				},
+				SecretName:  "secretname",
+				SslNoVerify: true,
+			},
+			expected: fmt.Sprintf("%sgit clone %s %s && cd %s && %sgit checkout %s && rm -r .git && cp -r %s/. /bundle",
+				"GIT_SSL_NO_VERIFY=true ", "https://$USER:$TOKEN@github.com/operator-framework/combo", repositoryName, repositoryName, "GIT_SSL_NO_VERIFY=true ", "4567031e158b42263e70a7c63e29f8981a4a6135",
+				"./"),
+		},
 	}
 
 	for _, tt := range gitSources {

--- a/internal/provisioner/plain/controllers/bundle_controller.go
+++ b/internal/provisioner/plain/controllers/bundle_controller.go
@@ -484,6 +484,12 @@ func bundleGitRepoPod(pod *corev1.Pod, source rukpakv1alpha1.GitSource, unpackIm
 	}
 	pod.Spec.InitContainers[1].Command = []string{"/bin/sh", "-c", cmd}
 	pod.Spec.InitContainers[1].VolumeMounts = []corev1.VolumeMount{{Name: "bundle", MountPath: "/bundle"}}
+	if source.SecretName != "" {
+		pod.Spec.InitContainers[1].Env = []corev1.EnvVar{
+			{Name: "USER", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: source.SecretName}, Key: "username"}}},
+			{Name: "TOKEN", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: source.SecretName}, Key: "accesstoken"}}},
+		}
+	}
 
 	if len(pod.Spec.Containers) != 1 {
 		pod.Spec.Containers = make([]corev1.Container, 1)

--- a/manifests/apis/crds/core.rukpak.io_bundleinstances.yaml
+++ b/manifests/apis/crds/core.rukpak.io_bundleinstances.yaml
@@ -126,6 +126,18 @@ spec:
                                   containing the bundle. Repository is required and
                                   the URL should be parsable by a standard git tool.
                                 type: string
+                              secretName:
+                                description: SecretName contains the secret name that
+                                  has authorization information for HTTPS protocol
+                                  and is in the namespace that the provisioner is
+                                  deployed. The secret is expected to contain `data.username`
+                                  and `data.accesstoken` for the username and personal
+                                  access token, respectively.
+                                type: string
+                              sslNoVerify:
+                                description: If SslNoVerify is set true, the server
+                                  certificate is ignored.
+                                type: boolean
                             required:
                             - ref
                             - repository

--- a/manifests/apis/crds/core.rukpak.io_bundles.yaml
+++ b/manifests/apis/crds/core.rukpak.io_bundles.yaml
@@ -94,6 +94,17 @@ spec:
                           containing the bundle. Repository is required and the URL
                           should be parsable by a standard git tool.
                         type: string
+                      secretName:
+                        description: SecretName contains the secret name that has
+                          authorization information for HTTPS protocol and is in the
+                          namespace that the provisioner is deployed. The secret is
+                          expected to contain `data.username` and `data.accesstoken`
+                          for the username and personal access token, respectively.
+                        type: string
+                      sslNoVerify:
+                        description: If SslNoVerify is set true, the server certificate
+                          is ignored.
+                        type: boolean
                     required:
                     - ref
                     - repository


### PR DESCRIPTION
Signed-off-by: akihikokuroda <akuroda@us.ibm.com>

Add `Secret` at the top-level in the Bundle.Spec and removed `ImagePullSecretName` from `ImageSource`
```
        // Secret contains the secret name that has authorization information for the source and is	in the namespace that the provisioner is deployed.
	// for image source, the secret contains the image pull secret.
	// for git source, the secret contains the user ID (key: user) and the personal access token to the repository (key: token)
	Secret string `json:"secret,omitempty"`
```

Closes #285 