### PR TITLE
FIX: human readable BundeInstance success messages

### DIFF
--- a/internal/provisioner/plain/controllers/bundleinstance_controller.go
+++ b/internal/provisioner/plain/controllers/bundleinstance_controller.go
@@ -263,9 +263,10 @@ func (r *BundleInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 	meta.SetStatusCondition(&bi.Status.Conditions, metav1.Condition{
-		Type:   rukpakv1alpha1.TypeInstalled,
-		Status: metav1.ConditionTrue,
-		Reason: rukpakv1alpha1.ReasonInstallationSucceeded,
+		Type:    rukpakv1alpha1.TypeInstalled,
+		Status:  metav1.ConditionTrue,
+		Reason:  rukpakv1alpha1.ReasonInstallationSucceeded,
+		Message: fmt.Sprintf("instantiated bundle %s successfully", bi.Spec.BundleName),
 	})
 	bi.Status.InstalledBundleName = bi.Spec.BundleName
 	return ctrl.Result{}, nil

--- a/test/e2e/plain_provisioner_test.go
+++ b/test/e2e/plain_provisioner_test.go
@@ -740,7 +740,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 					Type:    rukpakv1alpha1.TypeInstalled,
 					Status:  metav1.ConditionStatus(corev1.ConditionTrue),
 					Reason:  rukpakv1alpha1.ReasonInstallationSucceeded,
-					Message: "",
+					Message: fmt.Sprintf("instantiated bundle %s successfully", bi.Spec.BundleName),
 				}
 				return conditionsSemanticallyEqual(expected, *existing)
 			}).Should(BeTrue())
@@ -770,7 +770,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 					Type:    rukpakv1alpha1.TypeInstalled,
 					Status:  metav1.ConditionStatus(corev1.ConditionTrue),
 					Reason:  rukpakv1alpha1.ReasonInstallationSucceeded,
-					Message: "",
+					Message: fmt.Sprintf("instantiated bundle %s successfully", bi.Spec.BundleName),
 				}
 
 				// Find the HasValidBundle status
@@ -991,7 +991,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 					WithTransform(func(c *metav1.Condition) string { return c.Type }, Equal(rukpakv1alpha1.TypeInstalled)),
 					WithTransform(func(c *metav1.Condition) metav1.ConditionStatus { return c.Status }, Equal(metav1.ConditionTrue)),
 					WithTransform(func(c *metav1.Condition) string { return c.Reason }, Equal(rukpakv1alpha1.ReasonInstallationSucceeded)),
-					WithTransform(func(c *metav1.Condition) string { return c.Message }, Equal("")),
+					WithTransform(func(c *metav1.Condition) string { return c.Message }, Equal(fmt.Sprintf("instantiated bundle %s successfully", dependentBI.Spec.BundleName))),
 				))
 			})
 		})
@@ -1117,9 +1117,10 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 					return false
 				}
 				expected := metav1.Condition{
-					Type:   rukpakv1alpha1.TypeInstalled,
-					Status: metav1.ConditionStatus(corev1.ConditionTrue),
-					Reason: rukpakv1alpha1.ReasonInstallationSucceeded,
+					Type:    rukpakv1alpha1.TypeInstalled,
+					Status:  metav1.ConditionStatus(corev1.ConditionTrue),
+					Reason:  rukpakv1alpha1.ReasonInstallationSucceeded,
+					Message: fmt.Sprintf("instantiated bundle %s successfully", biOriginal.Spec.BundleName),
 				}
 				return conditionsSemanticallyEqual(*existing, expected)
 			}).Should(BeTrue())
@@ -1253,7 +1254,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 				WithTransform(func(c *metav1.Condition) string { return c.Type }, Equal(rukpakv1alpha1.TypeInstalled)),
 				WithTransform(func(c *metav1.Condition) metav1.ConditionStatus { return c.Status }, Equal(metav1.ConditionTrue)),
 				WithTransform(func(c *metav1.Condition) string { return c.Reason }, Equal(rukpakv1alpha1.ReasonInstallationSucceeded)),
-				WithTransform(func(c *metav1.Condition) string { return c.Message }, Equal("")),
+				WithTransform(func(c *metav1.Condition) string { return c.Message }, Equal(fmt.Sprintf("instantiated bundle %s successfully", bi.Spec.BundleName))),
 			))
 		})
 		AfterEach(func() {
@@ -1443,7 +1444,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 				WithTransform(func(c *metav1.Condition) string { return c.Type }, Equal(rukpakv1alpha1.TypeInstalled)),
 				WithTransform(func(c *metav1.Condition) metav1.ConditionStatus { return c.Status }, Equal(metav1.ConditionTrue)),
 				WithTransform(func(c *metav1.Condition) string { return c.Reason }, Equal(rukpakv1alpha1.ReasonInstallationSucceeded)),
-				WithTransform(func(c *metav1.Condition) string { return c.Message }, Equal("")),
+				WithTransform(func(c *metav1.Condition) string { return c.Message }, Equal(fmt.Sprintf("instantiated bundle %s successfully", bi.Spec.BundleName))),
 			))
 		})
 		AfterEach(func() {


### PR DESCRIPTION
Modifies bundleinstance_controller to include human readable message in
message field after successful installation of a BundleInstance
resource.

Modifies associated tests to represent that change.