### PR TITLE
WIP: Rename singleton image to align with what it contains

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,3 @@ COPY core core
 COPY crdvalidator crdvalidator
 
 EXPOSE 8080
-ENTRYPOINT ["/plain"]

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 ###########################
 ORG := github.com/operator-framework
 PKG := $(ORG)/rukpak
-export IMAGE_REPO ?= quay.io/operator-framework/plain-provisioner
+export IMAGE_REPO ?= quay.io/operator-framework/rukpak
 export IMAGE_TAG ?= latest
 IMAGE?=$(IMAGE_REPO):$(IMAGE_TAG)
 KIND_CLUSTER_NAME ?= kind

--- a/docs/plain-bundle-spec.md
+++ b/docs/plain-bundle-spec.md
@@ -130,13 +130,13 @@ EOF
    have push access to. For example,
 
 ```bash
-docker build -f Dockerfile.example -t quay.io/operator-framework/plain-provisioner:example .
+docker build -f Dockerfile.example -t quay.io/operator-framework/rukpak:example .
 ```
 
 6. Push the image to the remote registry
 
 ```bash
-docker push quay.io/operator-framework/plain-provisioner:example
+docker push quay.io/operator-framework/rukpak:example
 ```
 
 7. Make sure rukpak is installed locally on a running cluster.
@@ -157,7 +157,7 @@ spec:
   source:
     type: image
     image:
-      ref: quay.io/operator-framework/plain-provisioner:example
+      ref: quay.io/operator-framework/rukpak:example
   provisionerClassName: core.rukpak.io/plain
 EOF
 ```

--- a/internal/provisioner/plain/main.go
+++ b/internal/provisioner/plain/main.go
@@ -64,7 +64,7 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&systemNamespace, "system-namespace", "rukpak-system", "Configures the namespace that gets used to deploy system resources.")
-	flag.StringVar(&unpackImage, "unpack-image", "quay.io/operator-framework/plain-provisioner:latest", "Configures the container image that gets used to unpack Bundle contents.")
+	flag.StringVar(&unpackImage, "unpack-image", "quay.io/operator-framework/rukpak:latest", "Configures the container image that gets used to unpack Bundle contents.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")

--- a/manifests/apis/webhooks/resources/deployment.yaml
+++ b/manifests/apis/webhooks/resources/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         - name: core-webhook
           command: ["/core"]
           args: ["run"]
-          image: quay.io/operator-framework/plain-provisioner:latest
+          image: quay.io/operator-framework/rukpak:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/manifests/crdvalidator/05_deployment.yaml
+++ b/manifests/crdvalidator/05_deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       serviceAccountName: crd-validation-webhook
       containers:
-        - image: quay.io/operator-framework/plain-provisioner:latest
+        - image: quay.io/operator-framework/rukpak:latest
           imagePullPolicy: IfNotPresent
           command: ["/crdvalidator"]
           name: crd-validation-webhook

--- a/manifests/provisioners/plain/resources/deployment.yaml
+++ b/manifests/provisioners/plain/resources/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       containers:
         - name: plain-provisioner
           image: quay.io/operator-framework/rukpak:latest
+          command: ["/plain"]
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/manifests/provisioners/plain/resources/deployment.yaml
+++ b/manifests/provisioners/plain/resources/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: plain-provisioner-admin
       containers:
         - name: plain-provisioner
-          image: quay.io/operator-framework/plain-provisioner:latest
+          image: quay.io/operator-framework/rukpak:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080


### PR DESCRIPTION
PR to change singleton image name to align with its contents, remove the default `/plain` entrypoint and add that command directly in the relevant deployment.

Closes https://github.com/operator-framework/rukpak/issues/284