### PR TITLE
internal,test: Add a package that contains the unique provisioner IDs

### DIFF
--- a/internal/provisioner/plain/controllers/bundle_controller.go
+++ b/internal/provisioner/plain/controllers/bundle_controller.go
@@ -43,6 +43,7 @@ import (
 
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	"github.com/operator-framework/rukpak/internal/git"
+	plain "github.com/operator-framework/rukpak/internal/provisioner/plain/types"
 	"github.com/operator-framework/rukpak/internal/storage"
 	"github.com/operator-framework/rukpak/internal/updater"
 	"github.com/operator-framework/rukpak/internal/util"
@@ -382,7 +383,7 @@ func getObjects(bundleFS fs.FS) ([]client.Object, error) {
 func (r *BundleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&rukpakv1alpha1.Bundle{}, builder.WithPredicates(
-			util.BundleProvisionerFilter(plainBundleProvisionerID),
+			util.BundleProvisionerFilter(plain.ProvisionerID),
 		)).
 		Owns(&corev1.Secret{}).
 		Owns(&corev1.Pod{}).

--- a/internal/provisioner/plain/controllers/bundleinstance_controller.go
+++ b/internal/provisioner/plain/controllers/bundleinstance_controller.go
@@ -46,12 +46,9 @@ import (
 
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	helmpredicate "github.com/operator-framework/rukpak/internal/helm-operator-plugins/predicate"
+	plain "github.com/operator-framework/rukpak/internal/provisioner/plain/types"
 	"github.com/operator-framework/rukpak/internal/storage"
 	"github.com/operator-framework/rukpak/internal/util"
-)
-
-const (
-	plainBundleProvisionerID = "core.rukpak.io/plain"
 )
 
 // BundleInstanceReconciler reconciles a BundleInstance object
@@ -95,7 +92,7 @@ func (r *BundleInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	defer func() {
 		bi := bi.DeepCopy()
 		bi.ObjectMeta.ManagedFields = nil
-		if err := r.Status().Patch(ctx, bi, client.Apply, client.FieldOwner(plainBundleProvisionerID)); err != nil {
+		if err := r.Status().Patch(ctx, bi, client.Apply, client.FieldOwner(plain.ProvisionerID)); err != nil {
 			l.Error(err, "failed to patch status")
 		}
 	}()
@@ -344,7 +341,7 @@ func (r *BundleInstanceReconciler) loadBundle(ctx context.Context, bi *rukpakv1a
 // SetupWithManager sets up the controller with the Manager.
 func (r *BundleInstanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	controller, err := ctrl.NewControllerManagedBy(mgr).
-		For(&rukpakv1alpha1.BundleInstance{}, builder.WithPredicates(util.BundleInstanceProvisionerFilter(plainBundleProvisionerID))).
+		For(&rukpakv1alpha1.BundleInstance{}, builder.WithPredicates(util.BundleInstanceProvisionerFilter(plain.ProvisionerID))).
 		Watches(&source.Kind{Type: &rukpakv1alpha1.Bundle{}}, handler.EnqueueRequestsFromMapFunc(util.MapBundleToBundleInstanceHandler(mgr.GetClient(), mgr.GetLogger()))).
 		Build(r)
 	if err != nil {

--- a/internal/provisioner/plain/types/types.go
+++ b/internal/provisioner/plain/types/types.go
@@ -1,0 +1,6 @@
+package plain
+
+const (
+	// ProvisionerID is the unique plain provisioner ID
+	ProvisionerID = "core.rukpak.io/plain"
+)

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -13,11 +13,8 @@ import (
 	pkgclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	plain "github.com/operator-framework/rukpak/internal/provisioner/plain/types"
 	"github.com/operator-framework/rukpak/internal/updater"
-)
-
-const (
-	provisionerClassName = "core.rukpak.io/plain"
 )
 
 var _ = Describe("Updater", func() {
@@ -67,7 +64,7 @@ var _ = Describe("Updater", func() {
 				Namespace: "testNamespace",
 			},
 			Spec: rukpakv1alpha1.BundleSpec{
-				ProvisionerClassName: provisionerClassName,
+				ProvisionerClassName: plain.ProvisionerID,
 				Source: rukpakv1alpha1.BundleSource{
 					Type: rukpakv1alpha1.SourceTypeImage,
 					Image: &rukpakv1alpha1.ImageSource{

--- a/test/e2e/plain_provisioner_test.go
+++ b/test/e2e/plain_provisioner_test.go
@@ -22,13 +22,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	plain "github.com/operator-framework/rukpak/internal/provisioner/plain/types"
 	"github.com/operator-framework/rukpak/internal/util"
 )
 
 const (
 	// TODO: make this is a CLI flag?
 	defaultSystemNamespace = "rukpak-system"
-	plainProvisionerID     = "core.rukpak.io/plain"
 )
 
 func Logf(f string, v ...interface{}) {
@@ -53,7 +53,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					GenerateName: "olm-crds-valid",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -219,7 +219,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					GenerateName: "olm-crds-invalid",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -293,7 +293,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					GenerateName: "olm-crds-unsupported",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -342,7 +342,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					GenerateName: "olm-crds-unsupported",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -396,7 +396,7 @@ var _ = Describe("plain provisioner bundle", func() {
 						GenerateName: "combo-git-commit",
 					},
 					Spec: rukpakv1alpha1.BundleSpec{
-						ProvisionerClassName: plainProvisionerID,
+						ProvisionerClassName: plain.ProvisionerID,
 						Source: rukpakv1alpha1.BundleSource{
 							Type: rukpakv1alpha1.SourceTypeGit,
 							Git: &rukpakv1alpha1.GitSource{
@@ -453,7 +453,7 @@ var _ = Describe("plain provisioner bundle", func() {
 						GenerateName: "combo-git-tag",
 					},
 					Spec: rukpakv1alpha1.BundleSpec{
-						ProvisionerClassName: plainProvisionerID,
+						ProvisionerClassName: plain.ProvisionerID,
 						Source: rukpakv1alpha1.BundleSource{
 							Type: rukpakv1alpha1.SourceTypeGit,
 							Git: &rukpakv1alpha1.GitSource{
@@ -510,7 +510,7 @@ var _ = Describe("plain provisioner bundle", func() {
 						GenerateName: "combo-git-branch",
 					},
 					Spec: rukpakv1alpha1.BundleSpec{
-						ProvisionerClassName: plainProvisionerID,
+						ProvisionerClassName: plain.ProvisionerID,
 						Source: rukpakv1alpha1.BundleSource{
 							Type: rukpakv1alpha1.SourceTypeGit,
 							Git: &rukpakv1alpha1.GitSource{
@@ -567,7 +567,7 @@ var _ = Describe("plain provisioner bundle", func() {
 						GenerateName: "combo-git-custom-dir",
 					},
 					Spec: rukpakv1alpha1.BundleSpec{
-						ProvisionerClassName: plainProvisionerID,
+						ProvisionerClassName: plain.ProvisionerID,
 						Source: rukpakv1alpha1.BundleSource{
 							Type: rukpakv1alpha1.SourceTypeGit,
 							Git: &rukpakv1alpha1.GitSource{
@@ -634,7 +634,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					GenerateName: "namespace-subdirs",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -687,7 +687,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 					GenerateName: "olm-crds",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -704,7 +704,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 					GenerateName: "olm-crds",
 				},
 				Spec: rukpakv1alpha1.BundleInstanceSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					BundleName:           bundle.GetName(),
 				},
 			}
@@ -806,7 +806,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 					GenerateName: "olm-apis",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -823,7 +823,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 					GenerateName: "olm-apis",
 				},
 				Spec: rukpakv1alpha1.BundleInstanceSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					BundleName:           bundle.GetName(),
 				},
 			}
@@ -883,7 +883,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 					GenerateName: "e2e-bundle-dependent-",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -901,7 +901,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 					GenerateName: "e2e-bi-dependent-",
 				},
 				Spec: rukpakv1alpha1.BundleInstanceSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					BundleName:           dependentBundle.GetName(),
 				},
 			}
@@ -947,7 +947,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 						GenerateName: "e2e-bundle-providing-",
 					},
 					Spec: rukpakv1alpha1.BundleSpec{
-						ProvisionerClassName: plainProvisionerID,
+						ProvisionerClassName: plain.ProvisionerID,
 						Source: rukpakv1alpha1.BundleSource{
 							Type: rukpakv1alpha1.SourceTypeImage,
 							Image: &rukpakv1alpha1.ImageSource{
@@ -965,7 +965,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 						GenerateName: "e2e-bi-providing-",
 					},
 					Spec: rukpakv1alpha1.BundleInstanceSpec{
-						ProvisionerClassName: plainProvisionerID,
+						ProvisionerClassName: plain.ProvisionerID,
 						BundleName:           providesBundle.GetName(),
 					},
 				}
@@ -1012,7 +1012,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 					GenerateName: "e2e-bundle-crds-and-crs",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -1030,7 +1030,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 					GenerateName: "e2e-bi-crds-and-crs",
 				},
 				Spec: rukpakv1alpha1.BundleInstanceSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					BundleName:           bundle.GetName(),
 				},
 			}
@@ -1078,7 +1078,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 					GenerateName: "olm-crds-valid",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -1095,7 +1095,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 					GenerateName: "olm-apis-original",
 				},
 				Spec: rukpakv1alpha1.BundleInstanceSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					BundleName:           bundle.GetName(),
 				},
 			}
@@ -1129,7 +1129,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 					GenerateName: "olm-apis-duplicate",
 				},
 				Spec: rukpakv1alpha1.BundleInstanceSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					BundleName:           bundle.GetName(),
 				},
 			}
@@ -1199,7 +1199,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 					GenerateName: "e2e-original-bundle-crd-pivoting",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -1217,7 +1217,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 					GenerateName: "e2e-pivoted-bundle-crd-pivoting",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -1235,7 +1235,7 @@ var _ = Describe("plain provisioner bundleinstance", func() {
 					GenerateName: "e2e-bi-crd-pivoting",
 				},
 				Spec: rukpakv1alpha1.BundleInstanceSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					BundleName:           originalBundle.GetName(),
 				},
 			}
@@ -1335,7 +1335,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 					GenerateName: "e2e-ownerref-bundle-valid",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -1409,7 +1409,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 					GenerateName: "e2e-ownerref-bundle-valid",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -1426,7 +1426,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 					GenerateName: "e2e-ownerref-bi-valid",
 				},
 				Spec: rukpakv1alpha1.BundleInstanceSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					BundleName:           b.GetName(),
 				},
 			}

--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	plain "github.com/operator-framework/rukpak/internal/provisioner/plain/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -29,7 +30,7 @@ var _ = Describe("bundle api validating webhook", func() {
 					GenerateName: "valid-bundle-",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -64,7 +65,7 @@ var _ = Describe("bundle api validating webhook", func() {
 					Name: "bundlename-0123456789012345678901234567891",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -99,7 +100,7 @@ var _ = Describe("bundle api validating webhook", func() {
 					Name: "bundlenamegit",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeGit,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -134,7 +135,7 @@ var _ = Describe("bundle api validating webhook", func() {
 					Name: "bundlenamemorerefs",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeGit,
 						Git: &rukpakv1alpha1.GitSource{
@@ -173,7 +174,7 @@ var _ = Describe("bundle api validating webhook", func() {
 					Name: "bundlenameimage",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plainProvisionerID,
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Git: &rukpakv1alpha1.GitSource{


### PR DESCRIPTION
Introduce a types.go package that contains the constant variables used throughout the plain provisioner implementation. Update references to that plain provisioner unique ID to point to that consistent constant variable vs. scattering this information across the repository.