### PR TITLE
api,manifests: Add a short name for the BundleInstance API

### DIFF
--- a/api/v1alpha1/bundleinstance_types.go
+++ b/api/v1alpha1/bundleinstance_types.go
@@ -61,8 +61,8 @@ type BundleInstanceStatus struct {
 }
 
 //+kubebuilder:object:root=true
-//+kubebuilder:resource:scope=Cluster
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:scope=Cluster,shortName={"bi","bis"}
 //+kubebuilder:printcolumn:name="Desired Bundle",type=string,JSONPath=`.spec.bundleName`
 //+kubebuilder:printcolumn:name="Installed Bundle",type=string,JSONPath=`.status.installedBundleName`
 //+kubebuilder:printcolumn:name="Install State",type=string,JSONPath=`.status.conditions[?(.type=="Installed")].reason`

--- a/manifests/apis/crds/core.rukpak.io_bundleinstances.yaml
+++ b/manifests/apis/crds/core.rukpak.io_bundleinstances.yaml
@@ -13,6 +13,9 @@ spec:
     kind: BundleInstance
     listKind: BundleInstanceList
     plural: bundleinstances
+    shortNames:
+    - bi
+    - bis
     singular: bundleinstance
   scope: Cluster
   versions:


### PR DESCRIPTION
Update the kubebuilder markers for the BI types.go definition and add a shortName configuration that allows users to interact with bundleinstance resources locally without typing out the full name.