### PR TITLE
Add support for serving bundle content

### DIFF
--- a/api/v1alpha1/bundle_types.go
+++ b/api/v1alpha1/bundle_types.go
@@ -104,6 +104,7 @@ type BundleStatus struct {
 	Digest             string             `json:"digest,omitempty"`
 	ObservedGeneration int64              `json:"observedGeneration,omitempty"`
 	Conditions         []metav1.Condition `json:"conditions,omitempty"`
+	ContentURL         string             `json:"contentURL,omitempty"`
 }
 
 type BundleInfo struct {

--- a/internal/storage/localdir_test.go
+++ b/internal/storage/localdir_test.go
@@ -44,7 +44,7 @@ var _ = Describe("LocalDirectory", func() {
 		Describe("Store", func() {
 			It("should store a bundle FS", func() {
 				Expect(store.Store(ctx, owner, testFS)).To(Succeed())
-				_, err := os.Stat(filepath.Join(store.RootDirectory, fmt.Sprintf("%s.tgz", owner.GetUID())))
+				_, err := os.Stat(filepath.Join(store.RootDirectory, fmt.Sprintf("%s.tgz", owner.GetName())))
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -83,7 +83,7 @@ var _ = Describe("LocalDirectory", func() {
 		Describe("Delete", func() {
 			It("should delete the bundle", func() {
 				Expect(store.Delete(ctx, owner)).To(Succeed())
-				_, err := os.Stat(filepath.Join(store.RootDirectory, fmt.Sprintf("%s.tgz", owner.GetUID())))
+				_, err := os.Stat(filepath.Join(store.RootDirectory, fmt.Sprintf("%s.tgz", owner.GetName())))
 				Expect(err).To(WithTransform(func(err error) bool { return errors.Is(err, os.ErrNotExist) }, BeTrue()))
 			})
 		})

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"io/fs"
+	"net/http"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -11,4 +12,7 @@ type Storage interface {
 	Load(ctx context.Context, owner client.Object) (fs.FS, error)
 	Store(ctx context.Context, owner client.Object, bundle fs.FS) error
 	Delete(ctx context.Context, owner client.Object) error
+
+	http.Handler
+	URLFor(ctx context.Context, owner client.Object) (string, error)
 }

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -100,6 +100,16 @@ func EnsureBundleDigest(digest string) UpdateStatusFunc {
 	}
 }
 
+func EnsureContentURL(url string) UpdateStatusFunc {
+	return func(status *rukpakv1alpha1.BundleStatus) bool {
+		if status.ContentURL == url {
+			return false
+		}
+		status.ContentURL = url
+		return true
+	}
+}
+
 func UnsetBundleInfo() UpdateStatusFunc {
 	return SetBundleInfo(nil)
 }

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -150,6 +150,25 @@ var _ = Describe("EnsureBundleDigest", func() {
 	})
 })
 
+var _ = Describe("EnsureContentURL", func() {
+	var status *rukpakv1alpha1.BundleStatus
+
+	BeforeEach(func() {
+		status = &rukpakv1alpha1.BundleStatus{}
+	})
+
+	It("should add ContentURL if not present", func() {
+		Expect(updater.EnsureContentURL("url")(status)).To(BeTrue())
+		Expect(status.ContentURL).To(Equal("url"))
+	})
+
+	It("should return false for no update", func() {
+		status.ContentURL = "url"
+		Expect(updater.EnsureContentURL("url")(status)).To(BeFalse())
+		Expect(status.ContentURL).To(Equal("url"))
+	})
+})
+
 var _ = Describe("EnsureCondition", func() {
 	var status *rukpakv1alpha1.BundleStatus
 	var condition, anotherCondition metav1.Condition

--- a/manifests/apis/crds/core.rukpak.io_bundles.yaml
+++ b/manifests/apis/crds/core.rukpak.io_bundles.yaml
@@ -196,6 +196,8 @@ spec:
                   - type
                   type: object
                 type: array
+              contentURL:
+                type: string
               digest:
                 type: string
               info:

--- a/manifests/provisioners/plain/kustomization.yaml
+++ b/manifests/provisioners/plain/kustomization.yaml
@@ -1,5 +1,21 @@
 resources:
-  - resources/serviceaccount.yaml
+  - resources/bundle_reader_client_clusterrole.yaml
   - resources/cluster_role.yaml
   - resources/cluster_role_binding.yaml
   - resources/deployment.yaml
+  - resources/service.yaml
+  - resources/serviceaccount.yaml
+
+vars:
+  - name: PLAIN_PROVISIONER_SERVICE_NAMESPACE # namespace of the service
+    objref:
+      kind: Service
+      version: v1
+      name: plain-provisioner
+    fieldref:
+      fieldpath: metadata.namespace
+  - name: PLAIN_PROVISIONER_SERVICE_NAME
+    objref:
+      kind: Service
+      version: v1
+      name: plain-provisioner

--- a/manifests/provisioners/plain/resources/bundle_reader_client_clusterrole.yaml
+++ b/manifests/provisioners/plain/resources/bundle_reader_client_clusterrole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bundle-reader
+rules:
+  - nonResourceURLs:
+      - /bundles/*
+    verbs:
+      - get

--- a/manifests/provisioners/plain/resources/cluster_role.yaml
+++ b/manifests/provisioners/plain/resources/cluster_role.yaml
@@ -13,6 +13,18 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - ""
   resources:
   - pods

--- a/manifests/provisioners/plain/resources/deployment.yaml
+++ b/manifests/provisioners/plain/resources/deployment.yaml
@@ -17,10 +17,24 @@ spec:
     spec:
       serviceAccountName: plain-provisioner-admin
       containers:
-        - name: plain-provisioner
+        - name: kube-rbac-proxy
+          image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+          args:
+            - "--secure-listen-address=0.0.0.0:8443"
+            - "--upstream=http://127.0.0.1:8080/"
+            - "--logtostderr=true"
+            - "--v=1"
+          ports:
+            - containerPort: 8443
+              protocol: TCP
+              name: https
+        - name: manager
           image: quay.io/operator-framework/rukpak:latest
-          command: ["/plain"]
           imagePullPolicy: IfNotPresent
+          command: ["/plain"]
+          args:
+            - "--http-bind-address=127.0.0.1:8080"
+            - "--http-external-address=https://$(PLAIN_PROVISIONER_SERVICE_NAME).$(PLAIN_PROVISIONER_SERVICE_NAMESPACE).svc"
           ports:
             - containerPort: 8080
           volumeMounts:

--- a/manifests/provisioners/plain/resources/service.yaml
+++ b/manifests/provisioners/plain/resources/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: rukpak-system
+  name: plain-provisioner
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app: plain-provisioner

--- a/test/e2e/plain_provisioner_test.go
+++ b/test/e2e/plain_provisioner_test.go
@@ -1406,8 +1406,8 @@ func checkProvisionerBundle(object client.Object, provisionerPodName string) err
 		Name(provisionerPodName).
 		SubResource("exec").
 		VersionedParams(&corev1.PodExecOptions{
-			Container: "plain-provisioner",
-			Command:   []string{"ls", filepath.Join(storage.DefaultBundleCacheDir, fmt.Sprintf("%s.tgz", object.GetUID()))},
+			Container: "manager",
+			Command:   []string{"ls", filepath.Join(storage.DefaultBundleCacheDir, fmt.Sprintf("%s.tgz", object.GetName()))},
 			Stdin:     true,
 			Stdout:    true,
 			Stderr:    true,


### PR DESCRIPTION
This PR works toward closing #311.

It does several things:
1. Adds a new `status.contentURL` to the Bundle API
1. Updates the storage interface to include an HTTP handler to serve bundle content
1. Updates the storage interface to allow a provisioner to get a URL for a bundle
1. Updates the `LocalDirectory` storage implementation to implement 2 and 3
1. Updates the `LocalDirectory` storage implementation to use bundle name rather than bundle UID for better UX (both are unique to bundles throughout the cluster since bundles are cluster-scoped)
1. Updates the plain provisioner to register the storage HTTP handler on the existing controller-runtime webserver, under the `/bundles` path.
1. Updates the plain provisioner to populate the `status.contentURL` field when bundles are successfully unpacked
1. Adds a kube-rbac-proxy container that protects the bundle content. This is important because bundle content can contain secrets and other sensitive information.
1. Adds a bundle-reader cluster-role that clients can bind to to gain access to the bundle content.

To fully close #311, we need to do a few more things:
1. Update documentation about this functionality, including something for a provisioner spec that says provisioners MUST implement bundle content serving.
1. Update e2e tests to verify correct web server and kube-rbac-proxy functionality.

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>