### PR TITLE
manifests: Add the default logs container annotation for the plain provisioner deployment

### DIFF
--- a/manifests/provisioners/plain/resources/deployment.yaml
+++ b/manifests/provisioners/plain/resources/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         app: plain-provisioner
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
     spec:
       serviceAccountName: plain-provisioner-admin
       containers:


### PR DESCRIPTION
Update the plain provisioner deployment manifest and add the [`kubectl.kubernetes.io/default-logs-container` annotation](https://github.com/kubernetes/kubernetes/pull/87809) so there's no need to specify the container (-c) flag when interacting with kubectl log commands.

Signed-off-by: timflannagan <timflannagan@gmail.com>