### PR TITLE
ci: Automate the process of generating the rukpak release manifests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,11 @@ jobs:
           echo IMAGE_TAG="$(git describe --tags --always)" >> $GITHUB_ENV
         fi
 
+    - name: Generate the rukpak release manifests
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      run: |
+        make quickstart VERSION=${GITHUB_REF#refs/tags/}
+
     - name: Run goreleaser
       run: make release
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,7 @@
 vendor/
 bin/
 dist/
+
+# Release artifacts
 .goreleaser.yml
+rukpak.yaml

--- a/.goreleaser.template.yml
+++ b/.goreleaser.template.yml
@@ -105,3 +105,5 @@ changelog:
   skip: $DISABLE_RELEASE_PIPELINE
 release:
   disable: $DISABLE_RELEASE_PIPELINE
+  extra_files:
+  - glob: 'rukpak.yaml'

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,10 @@ release: GORELEASER_ARGS ?= --snapshot --rm-dist
 release: goreleaser substitute
 	$(GORELEASER) $(GORELEASER_ARGS)
 
+quickstart: VERSION ?= $(shell git describe --abbrev=0 --tags)
+quickstart: generate kustomize
+	$(KUSTOMIZE) build manifests | sed "s/:latest/:$(VERSION)/g" > rukpak.yaml
+
 controller-gen: $(CONTROLLER_GEN) ## Build a local copy of controller-gen
 ginkgo: $(GINKGO) ## Build a local copy of ginkgo
 golangci-lint: $(GOLANGCI_LINT) ## Build a local copy of golangci-lint


### PR DESCRIPTION
# Summary

Automate the process of generating and attaching the rukpak.yaml release manifests that reference the container image tags built by goreleaser.

## Changes

- Add the `quickstart` target that's responsible for building the set of kustomize manifests in this repository, and substituting the default `quay.io/operator-framework/rukpak:latest` container image tag with the current image tags.
- Ensure the release GHA workflow now calls this `quickstart` Makefile target during tag event triggers
- Update the goreleaser template configuration file, and add a `extra_files` field in the release pipeline that attaches the rukpak.yaml file as an artifact.
- Ignore the generated rukpak.yaml release manifests locally.

## Misc.

- Closes #337 
- Related to #210 
- See https://github.com/timflannagan/rukpak/releases/tag/v0.3.1 for an example release that was created from these changes.