### PR TITLE
Add an installation header to the goreleaser configuration

### DIFF
--- a/.goreleaser.template.yml
+++ b/.goreleaser.template.yml
@@ -107,3 +107,14 @@ release:
   disable: $DISABLE_RELEASE_PIPELINE
   extra_files:
   - glob: 'rukpak.yaml'
+  header: |
+    ## Installation
+
+    ```bash
+    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/{{ .Env.CERT_MGR_VERSION }}/cert-manager.yaml
+    kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager-webhook --timeout=60s
+    kubectl apply -f https://github.com/operator-framework/rukpak/releases/download/{{ .Tag }}/rukpak.yaml
+    kubectl wait --for=condition=Available --namespace=rukpak-system deployment/plain-provisioner --timeout=60s
+    kubectl wait --for=condition=Available --namespace=rukpak-system deployment/core-webhook --timeout=60s
+    kubectl wait --for=condition=Available --namespace=crdvalidator-system deployment/crd-validation-webhook --timeout=60s
+    ```

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ TESTDATA_DIR := testdata
 VERSION_PATH := $(PKG)/internal/version
 GIT_COMMIT ?= $(shell git rev-parse HEAD)
 PKGS = $(shell go list ./...)
-CERT_MGR_VERSION=v1.7.1
+export CERT_MGR_VERSION ?= v1.7.1
 RUKPAK_NAMESPACE ?= rukpak-system
 
 CONTAINER_RUNTIME ?= docker


### PR DESCRIPTION
# Summary

Update the goreleaser template configuration file, and add a header field for injecting the installation instructions. The current release's tag will be substituted at runtime.

## Misc.

- Related to #337
- Related to #210
- See https://github.com/timflannagan/rukpak/releases/tag/v0.3.2 where I ran these changes against my fork

Signed-off-by: timflannagan <timflannagan@gmail.com>