### PR TITLE
Fix lint issues found from golangci-lint run

### DIFF
--- a/internal/provisioner/plain/controllers/bundleinstance_controller.go
+++ b/internal/provisioner/plain/controllers/bundleinstance_controller.go
@@ -384,18 +384,6 @@ func (r *BundleInstanceReconciler) getReleaseState(cl helmclient.ActionInterface
 	return currentRelease, stateUnchanged, nil
 }
 
-type errBundleNotUnpacked struct {
-	currentPhase string
-}
-
-func (err errBundleNotUnpacked) Error() string {
-	const baseError = "bundle is not yet unpacked"
-	if err.currentPhase == "" {
-		return baseError
-	}
-	return fmt.Sprintf("%s, current phase=%s", baseError, err.currentPhase)
-}
-
 func (r *BundleInstanceReconciler) loadBundle(ctx context.Context, bundle *rukpakv1alpha1.Bundle, biName string) ([]client.Object, error) {
 	bundleFS, err := r.BundleStorage.Load(ctx, bundle)
 	if err != nil {

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -5,13 +5,12 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/operator-framework/rukpak/api/v1alpha1"
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	plain "github.com/operator-framework/rukpak/internal/provisioner/plain/types"
 )
 
 func TestCheckDesiredBundleTemplate(t *testing.T) {
-	sampleSpec := v1alpha1.BundleSpec{
+	sampleSpec := rukpakv1alpha1.BundleSpec{
 		ProvisionerClassName: plain.ProvisionerID,
 		Source: rukpakv1alpha1.BundleSource{
 			Type: rukpakv1alpha1.SourceTypeImage,


### PR DESCRIPTION
Fixes a duplicate package import and removes a function that is no
longer being used.

These issues were found by simply running `golangci-lint run` locally -- doesn't look like our remote CI didn't pick these up, or at least causes a failure in that case. 