### PR TITLE
Add uninstall target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,9 @@ cert-mgr: ## Install the certification manager
 	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MGR_VERSION)/cert-manager.yaml
 	kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager-webhook --timeout=60s
 
+uninstall: ## Remove all rukpak resources from the cluster
+	kubectl delete -k manifests
+
 ##################
 # Build and Load #
 ##################


### PR DESCRIPTION
Adds an uninstall target to conveniently remove rukpak from the cluster
entirely. Relies on the kustomize output to build a list of objects to
remove.

<details>

```
rukpak(main): kustomize build manifests | kubectl delete -f -
namespace "crdvalidator-system" deleted
namespace "rukpak-system" deleted
customresourcedefinition.apiextensions.k8s.io "bundleinstances.core.rukpak.io" deleted
customresourcedefinition.apiextensions.k8s.io "bundles.core.rukpak.io" deleted
serviceaccount "crd-validation-webhook" deleted
serviceaccount "plain-provisioner-admin" deleted
serviceaccount "rukpak-core-admin" deleted
clusterrole.rbac.authorization.k8s.io "bundle-reader" deleted
clusterrole.rbac.authorization.k8s.io "crd-validation-webhook" deleted
clusterrole.rbac.authorization.k8s.io "plain-provisioner-admin" deleted
clusterrolebinding.rbac.authorization.k8s.io "crd-validation-webhook" deleted
clusterrolebinding.rbac.authorization.k8s.io "plain-provisioner-admin" deleted
service "crd-validation-webhook" deleted
service "plain-provisioner" deleted
service "rukpak-webhook-service" deleted
deployment.apps "crd-validation-webhook" deleted
deployment.apps "plain-provisioner" deleted
deployment.apps "rukpak-core-webhook" deleted
certificate.cert-manager.io "crd-validation-webhook-certificate" deleted
certificate.cert-manager.io "rukpak-webhook-certificate" deleted
issuer.cert-manager.io "selfsigned" deleted
issuer.cert-manager.io "rukpak-selfsigned" deleted
validatingwebhookconfiguration.admissionregistration.k8s.io "crd-validation-webhook" deleted
validatingwebhookconfiguration.admissionregistration.k8s.io "rukpak-validating-webhook-configuration" deleted
```
</details>
