### PR TITLE
.github: Refactor the sanity workflow

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -35,6 +35,11 @@ jobs:
 
       - name: Run golangci linting checks
         run: make lint
+  markdown:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
       - name: Lint markdown files
         uses: github/super-linter/slim@v4

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -20,11 +20,21 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Run golangci linting checks
-        uses: "golangci/golangci-lint-action@v2"
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Cache build and module paths
+        uses: actions/cache@v3
         with:
-          version: "v1.46.0"
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run golangci linting checks
+        run: make lint
 
       - name: Lint markdown files
         uses: github/super-linter/slim@v4


### PR DESCRIPTION
Update the lint GHA workflow job to use the lint Makefile target to ensure that both local/CI environments use the same entrypoint and version of golangci-lint. Add a step that caches the build and module paths to cut down on the overall runtime when running the lint job.

Separate the step responsible for linting the markdown files in the repository from lint job, into it's own job so that it can run in parallel with the other jobs defined in the sanity workflow.

Signed-off-by: timflannagan <timflannagan@gmail.com>