### PR TITLE
Add unique hash label to dynamic Bundle metadata

### DIFF
--- a/internal/util/hash.go
+++ b/internal/util/hash.go
@@ -1,0 +1,22 @@
+package util
+
+import (
+	"hash"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+// DeepHashObject writes specified object to hash using the spew library
+// which follows pointers and prints actual values of the nested objects
+// ensuring the hash does not change when a pointer changes.
+// From https://github.com/operator-framework/operator-lifecycle-manager/blob/master/pkg/lib/kubernetes/pkg/util/hash/hash.go
+func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
+	hasher.Reset()
+	printer := spew.ConfigState{
+		Indent:         " ",
+		SortKeys:       true,
+		DisableMethods: true,
+		SpewKeys:       true,
+	}
+	printer.Fprintf(hasher, "%#v", objectToWrite)
+}

--- a/internal/util/labels.go
+++ b/internal/util/labels.go
@@ -1,6 +1,7 @@
 package util
 
 const (
-	CoreOwnerKindKey = "core.rukpak.io/owner-kind"
-	CoreOwnerNameKey = "core.rukpak.io/owner-name"
+	CoreOwnerKindKey          = "core.rukpak.io/owner-kind"
+	CoreOwnerNameKey          = "core.rukpak.io/owner-name"
+	CoreBundleTemplateHashKey = "core.rukpak.io/bundle-template-hash"
 )

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -9,16 +9,17 @@ import (
 	plain "github.com/operator-framework/rukpak/internal/provisioner/plain/types"
 )
 
-func TestCheckDesiredBundleTemplate(t *testing.T) {
-	sampleSpec := rukpakv1alpha1.BundleSpec{
-		ProvisionerClassName: plain.ProvisionerID,
-		Source: rukpakv1alpha1.BundleSource{
-			Type: rukpakv1alpha1.SourceTypeImage,
-			Image: &rukpakv1alpha1.ImageSource{
-				Ref: "non-existent",
-			},
+var sampleSpec = rukpakv1alpha1.BundleSpec{
+	ProvisionerClassName: plain.ProvisionerID,
+	Source: rukpakv1alpha1.BundleSource{
+		Type: rukpakv1alpha1.SourceTypeImage,
+		Image: &rukpakv1alpha1.ImageSource{
+			Ref: "non-existent",
 		},
-	}
+	},
+}
+
+func TestCheckDesiredBundleTemplate(t *testing.T) {
 	type args struct {
 		existingBundle *rukpakv1alpha1.Bundle
 		desiredBundle  *rukpakv1alpha1.BundleTemplate
@@ -33,7 +34,7 @@ func TestCheckDesiredBundleTemplate(t *testing.T) {
 			args: args{
 				existingBundle: &rukpakv1alpha1.Bundle{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "stub",
+						Name: "stub-6f74b48d4",
 						Labels: map[string]string{
 							"stub": "stub",
 						},
@@ -57,7 +58,7 @@ func TestCheckDesiredBundleTemplate(t *testing.T) {
 			args: args{
 				existingBundle: &rukpakv1alpha1.Bundle{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "stub",
+						Name: "stub-6dd88668d7",
 						Labels: map[string]string{
 							"stub": "stub",
 						},
@@ -83,7 +84,7 @@ func TestCheckDesiredBundleTemplate(t *testing.T) {
 			args: args{
 				existingBundle: &rukpakv1alpha1.Bundle{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "stub",
+						Name: "stub-6f74b48d4",
 						Labels: map[string]string{
 							"stub": "stub",
 						},
@@ -107,7 +108,7 @@ func TestCheckDesiredBundleTemplate(t *testing.T) {
 			args: args{
 				existingBundle: &rukpakv1alpha1.Bundle{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "stub",
+						Name: "stub-77c4548c75",
 						Labels: map[string]string{
 							"stub": "stub",
 						},
@@ -132,10 +133,38 @@ func TestCheckDesiredBundleTemplate(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "True/BundleMatchesTemplateHyphens",
+			args: args{
+				existingBundle: &rukpakv1alpha1.Bundle{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "stub-123-6cc4cf6797",
+						Labels: map[string]string{
+							"stub-123": "stub-123",
+						},
+					},
+					Spec: sampleSpec,
+				},
+				desiredBundle: &rukpakv1alpha1.BundleTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "stub-123",
+						Labels: map[string]string{
+							"stub-123": "stub-123",
+						},
+					},
+					Spec: sampleSpec,
+				},
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			injectCoreLabels(tt.args.existingBundle)
+			// Dynamically inject the bundle template hash at runtime into the tests.
+			// This is due to the nature of the objects being passed in (pointers to BundleTemplates) being represented
+			// differently on different platforms, so hardcoding the hash values produces inconsistent results.
+			injectTemplateHashLabel(tt.args.existingBundle, tt.args.desiredBundle, tt.want)
 			if got := CheckDesiredBundleTemplate(tt.args.existingBundle, tt.args.desiredBundle); got != tt.want {
 				t.Errorf("CheckDesiredBundleTemplate() = %v, want %v", got, tt.want)
 			}
@@ -150,4 +179,13 @@ func injectCoreLabels(bundle *rukpakv1alpha1.Bundle) {
 	}
 	labels[CoreOwnerKindKey] = ""
 	labels[CoreOwnerNameKey] = ""
+}
+
+func injectTemplateHashLabel(bundle *rukpakv1alpha1.Bundle, template *rukpakv1alpha1.BundleTemplate, want bool) {
+	labels := bundle.GetLabels()
+	if want {
+		labels[CoreBundleTemplateHashKey] = GenerateTemplateHash(template)
+	} else {
+		labels[CoreBundleTemplateHashKey] = "00000000"
+	}
 }


### PR DESCRIPTION
Adds a unique hash label to the metadata of embedded bundles in the BI spec. The hash label is called `core.rukpak.io/bundle-template-hash` and the value is the fnv32a hash of the bundle template upon creation. 

Closes #334 