### PR TITLE
FIX: Fixes mis-capitalization of kind in makefile hack/tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ GINKGO := $(abspath $(TOOLS_BIN_DIR)/ginkgo)
 CONTROLLER_GEN := $(abspath $(TOOLS_BIN_DIR)/controller-gen)
 SETUP_ENVTEST := $(abspath $(TOOLS_BIN_DIR)/setup-envtest)
 GORELEASER := $(abspath $(TOOLS_BIN_DIR)/goreleaser)
-KIND := $(abspath $(TOOLS_BIN_DIR)/KIND)
+KIND := $(abspath $(TOOLS_BIN_DIR)/kind)
 
 controller-gen: $(CONTROLLER_GEN) ## Build a local copy of controller-gen
 ginkgo: $(GINKGO) ## Build a local copy of ginkgo


### PR DESCRIPTION
- Changes hack/tools kind directory from $(abspath $(TOOLS_BIN_DIR)/KIND)
to $(abspath $(TOOLS_BIN_DIR)/kind).