### PR TITLE
feat(makefile): update installation UX for Kind to be more seamless

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,11 +15,6 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '~1.18'
-
-    - name: Install kind binary
-      run: |
-        make kind
-
     - name: Run e2e tests
       run: |
-        make e2e KIND=hack/tools/bin/kind
+        make e2e

--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,9 @@ test-e2e: ginkgo ## Run the e2e tests
 e2e: KIND_CLUSTER_NAME=rukpak-e2e
 e2e: build-container kind-cluster kind-load kind-load-bundles run test-e2e ## Run e2e tests against a kind cluster
 
-kind-cluster: ## Standup a kind cluster for e2e testing usage
-	${KIND} delete cluster --name ${KIND_CLUSTER_NAME}
-	${KIND} create cluster --name ${KIND_CLUSTER_NAME}
+kind-cluster: kind ## Standup a kind cluster for e2e testing usage
+	$(KIND) delete cluster --name ${KIND_CLUSTER_NAME}
+	$(KIND) create cluster --name ${KIND_CLUSTER_NAME}
 
 ###################
 # Install and Run #
@@ -147,7 +147,7 @@ build-container: BIN_DIR:=$(BIN_DIR)/$(GOOS)
 build-container: build ## Builds provisioner container image locally
 	$(CONTAINER_RUNTIME) build -f Dockerfile -t $(IMAGE) $(BIN_DIR)
 
-kind-load-bundles: ## Load the e2e testdata container images into a kind cluster
+kind-load-bundles: kind ## Load the e2e testdata container images into a kind cluster
 	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/valid -t testdata/bundles/plain-v0:valid
 	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/dependent -t testdata/bundles/plain-v0:dependent
 	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/provides -t testdata/bundles/plain-v0:provides
@@ -156,17 +156,17 @@ kind-load-bundles: ## Load the e2e testdata container images into a kind cluster
 	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/invalid-missing-crds -t testdata/bundles/plain-v0:invalid-missing-crds
 	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/invalid-crds-and-crs -t testdata/bundles/plain-v0:invalid-crds-and-crs
 	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/subdir -t testdata/bundles/plain-v0:subdir
-	${KIND} load docker-image testdata/bundles/plain-v0:valid --name $(KIND_CLUSTER_NAME)
-	${KIND} load docker-image testdata/bundles/plain-v0:dependent --name $(KIND_CLUSTER_NAME)
-	${KIND} load docker-image testdata/bundles/plain-v0:provides --name $(KIND_CLUSTER_NAME)
-	${KIND} load docker-image testdata/bundles/plain-v0:empty --name $(KIND_CLUSTER_NAME)
-	${KIND} load docker-image testdata/bundles/plain-v0:no-manifests --name $(KIND_CLUSTER_NAME)
-	${KIND} load docker-image testdata/bundles/plain-v0:invalid-missing-crds --name $(KIND_CLUSTER_NAME)
-	${KIND} load docker-image testdata/bundles/plain-v0:invalid-crds-and-crs --name $(KIND_CLUSTER_NAME)
-	${KIND} load docker-image testdata/bundles/plain-v0:subdir --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image testdata/bundles/plain-v0:valid --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image testdata/bundles/plain-v0:dependent --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image testdata/bundles/plain-v0:provides --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image testdata/bundles/plain-v0:empty --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image testdata/bundles/plain-v0:no-manifests --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image testdata/bundles/plain-v0:invalid-missing-crds --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image testdata/bundles/plain-v0:invalid-crds-and-crs --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image testdata/bundles/plain-v0:subdir --name $(KIND_CLUSTER_NAME)
 
-kind-load: ## Loads the currently constructed image onto the cluster
-	${KIND} load docker-image $(IMAGE) --name $(KIND_CLUSTER_NAME)
+kind-load: kind ## Loads the currently constructed image onto the cluster
+	$(KIND) load docker-image $(IMAGE) --name $(KIND_CLUSTER_NAME)
 
 ###########
 # Release #

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ RukPak to a local [kind](https://kind.sigs.k8s.io/) cluster.
 
 ```bash
 git clone https://github.com/operator-framework/rukpak && cd rukpak
-make kind-cluster # If one is not already started
 make run
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ RukPak to a local [kind](https://kind.sigs.k8s.io/) cluster.
 
 ```bash
 git clone https://github.com/operator-framework/rukpak && cd rukpak
+make kind-cluster # If one is not already started
 make run
 ```
 

--- a/test/e2e/crdvalidator_test.go
+++ b/test/e2e/crdvalidator_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -153,7 +152,6 @@ var _ = Describe("crdvalidator", func() {
 					crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Required = []string{"sampleProperty"}
 
 					err := c.Update(ctx, crd)
-					fmt.Println(err)
 					if err != nil {
 						return err.Error()
 					}


### PR DESCRIPTION
Signed-off-by: Tyler Slaton <tyslaton@redhat.com>

## Summary 
Updating the UX of utilizing `kind` locally to be more seamless. 

The UX goes from:

```
make kind
make kind-cluster
make run
```

to

```
make kind-cluster
make run
```

Additionally, you can change which binary you're using (your own personal, the repo's, etc) by specifying the KIND variable.

```
make kind-cluster KIND=/usr/local/bin/kind
make run
```

Lastly, this PR also updates the `e2e` CI job to benefit from this change.

## Notes
A follow-up PR will be responsible for updating the docs to reflect this, found in #373.