### PR TITLE
Fix the Combo Operator Installation docs

### DIFF
--- a/internal/provisioner/plain/README.md
+++ b/internal/provisioner/plain/README.md
@@ -103,7 +103,8 @@ RBAC permissions to access bundle content.
 
 As an example, a client outside the cluster can view the file contents from a bundle named `my-bundle` by running
 the following script:
-```console
+
+```bash
 BUNDLE_NAME=my-bundle
 
 kubectl create sa fetch-bundle -n default
@@ -134,24 +135,29 @@ resources referenced by the bundle are present on the cluster.
 
 ### Setup
 
-To experiment with the `plain` provisioner locally, first setup a local cluster, or simply
-have [kind](https://kind.sigs.k8s.io/) installed locally.
+To experiment with the `plain` provisioner locally, take the following steps to
+create a local [kind](https://kind.sigs.k8s.io/) cluster and deploy the provisioner onto it:
 
-Once the cluster has been setup, take the following steps:
+```bash
+# Clone the repository
+git clone https://github.com/operator-framework/rukpak
 
-* Clone the repository via `git clone https://github.com/operator-framework/rukpak`
-* Navigate to the repository via `cd rukpak`
-* Run `make run` to build and deploy the provisioner onto the local cluster.
+# Navigate to the repository
+cd rukpak
+
+# Start a local kind cluster then build and deploy the provisioner onto it
+make run
+```
 
 ### Installing the Combo Operator
 
-From there, create some `Bundles` and `BundleInstance` types to see the provisioner in action. For an example bundle to
+From there, create some Bundles and BundleInstance types to see the provisioner in action. For an example bundle to
 use, the [combo operator](https://github.com/operator-framework/combo) is a good candidate.
 
-Create the combo `BundleInstance` referencing the desired combo `Bundle` configuration.
+Create the combo BundleInstance referencing the desired combo Bundle configuration:
 
-```console
-$ kubectl apply -f -<<EOF
+```bash
+kubectl apply -f -<<EOF
 apiVersion: core.rukpak.io/v1alpha1
 kind: BundleInstance
 metadata:
@@ -166,13 +172,27 @@ spec:
       provisionerClassName: core.rukpak.io/plain
       source:
         image:
-          ref: quay.io/tflannag/bundle:combo-operator-v0.0.1
+          ref: quay.io/operator-framework/combo-bundle:v0.0.1
         type: image
+EOF
+```
+
+A message saying that the BundleInstance is created should be returned:
+
+```console
+$ kubectl apply -f -<<EOF
+...
 EOF
 bundleinstance.core.rukpak.io/combo created
 ```
 
-Check the Bundle status via `kubectl get bundle -l app=combo`. Eventually the Bundle should show up as Unpacked.
+Next, check the Bundle status via:
+
+```bash
+kubectl get bundle -l app=combo
+```
+
+Eventually the Bundle should show up as Unpacked:
 
 ```console
 $ kubectl get bundle -l app=combo
@@ -180,7 +200,13 @@ NAME          TYPE   PHASE      AGE
 combo-9njsj   image  Unpacked   10s
 ```
 
-Check the BundleInstance status to ensure that the installation was successful.
+Check the BundleInstance status to ensure that the installation was successful:
+
+```bash
+kubectl get bundleinstance combo
+```
+
+A successful installation will show InstallationSucceeded as the `INSTALL STATE`:
 
 ```console
 $ kubectl get bundleinstance combo
@@ -188,7 +214,17 @@ NAME    INSTALLED BUNDLE   INSTALL STATE           AGE
 combo   combo-9njsj        InstallationSucceeded   10s
 ```
 
-From there, check out the combo operator deployment and ensure that the operator is present on the cluster.
+From there, check out the combo operator deployment and ensure that the operator is present on the cluster:
+
+```bash
+# Check the combo operator deployment
+kubectl -n combo get deployments.apps combo-operator
+
+# Check that the operator is present
+kubectl -n combo get deployments.apps combo-operator -o yaml | grep 'image:' | xargs
+```
+
+The deployment should show that the operator is ready and available:
 
 ```console
 $ kubectl -n combo get deployments.apps combo-operator
@@ -196,20 +232,32 @@ NAME             READY   UP-TO-DATE   AVAILABLE   AGE
 combo-operator   1/1     1            1           10s
 
 $ kubectl -n combo get deployments.apps combo-operator -o yaml | grep 'image:' | xargs
-image: quay.io/tflannag/combo:v0.0.1
+image: quay.io/operator-framework/combo-operator:v0.0.1
 ```
 
-The operator should be successfully installed.
+This means the operator should be successfully installed.
 
-Next, the `plain` provisioner continually reconciles BundleInstance resources. Let's try deleting the combo deployment:
+The `plain` provisioner continually reconciles BundleInstance resources. Next, let's try deleting the combo deployment:
+
+```bash
+kubectl -n combo delete deployments.apps combo-operator
+```
+
+A message saying the deployment was deleted should be returned:
 
 ```console
 $ kubectl -n combo delete deployments.apps combo-operator
 deployment.apps "combo-operator" deleted
 ```
 
-Check for the deployment again, it will be back on the cluster. The provisioner ensures that all resources required for
-the BundleInstance to run are accounted for on-cluster.
+The provisioner ensures that all resources required for the BundleInstance to run are accounted for on-cluster.
+So if we check for the deployment again, it will be back on the cluster:
+
+```console
+$ kubectl -n combo get deployments.apps combo-operator
+NAME             READY   UP-TO-DATE   AVAILABLE   AGE
+combo-operator   1/1     1            1           15s
+```
 
 ### Upgrading the Combo Operator
 
@@ -219,8 +267,8 @@ Let's say the combo operator released a new patch version, and we want to upgrad
 
 Update the existing `combo` BundleInstance resource and update the container image being referenced:
 
-```console
-$ kubectl apply -f -<<EOF
+```bash
+kubectl apply -f -<<EOF
 apiVersion: core.rukpak.io/v1alpha1
 kind: BundleInstance
 metadata:
@@ -235,51 +283,59 @@ spec:
       provisionerClassName: core.rukpak.io/plain
       source:
         image:
-          ref: quay.io/tflannag/bundle:combo-operator-v0.0.2
+          ref: quay.io/operator-framework/combo-bundle:v0.0.2
         type: image
 EOF
 ```
 
-And wait until the newly generated `combo-xzfxv` Bundle is reporting an Unpacked status:
+Once the newly generated Bundle (in this example, `combo-xzfxv`, your bundle may be named differently)
+is reporting an Unpacked status, the BundleInstance `combo` resource should now
+point to the new Bundle version. The combo-operator deployment
+in the combo namespace should also be healthy and contain a new container image:
 
 ```console
 $ kubectl get bundles -l app=combo
 NAME           TYPE    PHASE      AGE
-combo-9njsj     image  Unpacked   30s
+combo-9njsj    image   Unpacked   30s
 combo-xzfxv    image   Unpacked   10s
-```
 
-And verify that the BundleInstance `combo` resource now points to the new Bundle version:
-
-```console
 $ kubectl get bundleinstance combo
 NAME    INSTALLED BUNDLE   INSTALL STATE           AGE
 combo   combo-xzfxv        InstallationSucceeded   10s
-```
 
-And check that the combo-operator deployment in the combo namespace is healthy and contains a new container image:
-
-```console
 $ kubectl -n combo get deployment
 NAME             READY   UP-TO-DATE   AVAILABLE   AGE
 combo-operator   1/1     1            1           10s
 
 $ kubectl -n combo get deployments.apps combo-operator -o yaml | grep 'image:' | xargs
-image: quay.io/tflannag/combo:v0.0.2
+image: quay.io/operator-framework/combo-operator:v0.0.2
 ```
 
-Notice that the container image has changed since we had first installed the combo operator.
+Notice that the container image has changed to `v0.0.2` since we first installed the combo operator.
 
-### Deleting the Combo Operator
+### Deleting the Combo Operator and Local Kind Cluster
 
-To cleanup from the installation, simply remove the BundleInstance from the cluster. This will remove all references
+To clean up from the installation, simply remove the BundleInstance from the cluster. This will remove all references
 resources including the deployment, RBAC, and the operator namespace.
 
 > Note: There's no need to manually clean up the Bundles that were generated from a BundleInstance resource. The plain provisioner places owner references on any Bundle that's generated from an individual BundleInstance resource.
+
+```bash
+# Delete the combo BundleInstance
+kubectl delete bundleinstances.core.rukpak.io combo
+```
+
+A message should show that the BundleInstance was deleted and now the cluster state is the same as it was
+prior to installing the operator.
 
 ```console
 $ kubectl delete bundleinstances.core.rukpak.io combo
 bundleinstance.core.rukpak.io "combo" deleted
 ```
 
-The cluster state is now the same as it was prior to installing the operator.
+To stop and clean up the kind cluster, delete it:
+
+```bash
+# Clean up kind cluster
+make kind-cluster-cleanup
+```


### PR DESCRIPTION
The [Installing the Combo Operator](https://github.com/operator-framework/rukpak/tree/main/internal/provisioner/plain#installing-the-combo-operator) instructions referenced broken images. This PR updates those references to the correct images.

Closes: https://github.com/operator-framework/rukpak/issues/251

Cleaner version of [this PR](https://github.com/operator-framework/rukpak/pull/373).