### PR TITLE
release: Update the core webhook deployment name

### DIFF
--- a/.goreleaser.template.yml
+++ b/.goreleaser.template.yml
@@ -115,6 +115,6 @@ release:
     kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager-webhook --timeout=60s
     kubectl apply -f https://github.com/operator-framework/rukpak/releases/download/{{ .Tag }}/rukpak.yaml
     kubectl wait --for=condition=Available --namespace=rukpak-system deployment/plain-provisioner --timeout=60s
-    kubectl wait --for=condition=Available --namespace=rukpak-system deployment/core-webhook --timeout=60s
+    kubectl wait --for=condition=Available --namespace=rukpak-system deployment/rukpak-core-webhook --timeout=60s
     kubectl wait --for=condition=Available --namespace=crdvalidator-system deployment/crd-validation-webhook --timeout=60s
     ```


### PR DESCRIPTION
Update the goreleaser installation header section and fix the core rukpak webhook deployment name. The release manifests use kustomize as it's scaffolding tool, which has a [namePrefix](https://github.com/operator-framework/rukpak/blob/main/manifests/apis/webhooks/kustomization.yml#L2) specified but the quickstart instructions weren't updated to accommodate for that prefix.

See #328 which also has similar wait instructions and uses the rukpak-core-webhook deployment name.

Signed-off-by: timflannagan <timflannagan@gmail.com>