### PR TITLE
consider provisioner ID before enqueuing requests for bundles

### DIFF
--- a/api/v1alpha1/bundle_types.go
+++ b/api/v1alpha1/bundle_types.go
@@ -123,6 +123,10 @@ type Bundle struct {
 	Status BundleStatus `json:"status,omitempty"`
 }
 
+func (b *Bundle) ProvisionerClassName() string {
+	return b.Spec.ProvisionerClassName
+}
+
 //+kubebuilder:object:root=true
 
 // BundleList contains a list of Bundle

--- a/api/v1alpha1/bundle_webhook.go
+++ b/api/v1alpha1/bundle_webhook.go
@@ -30,9 +30,9 @@ import (
 // log is for logging in this package.
 var bundlelog = logf.Log.WithName("bundle-resource")
 
-func (r *Bundle) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (b *Bundle) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
-		For(r).
+		For(b).
 		Complete()
 }
 
@@ -41,27 +41,27 @@ func (r *Bundle) SetupWebhookWithManager(mgr ctrl.Manager) error {
 var _ webhook.Validator = &Bundle{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (r *Bundle) ValidateCreate() error {
-	bundlelog.V(1).Info("validate create", "name", r.Name)
+func (b *Bundle) ValidateCreate() error {
+	bundlelog.V(1).Info("validate create", "name", b.Name)
 
-	return checkBundleSource(r)
+	return checkBundleSource(b)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (r *Bundle) ValidateUpdate(old runtime.Object) error {
-	bundlelog.V(1).Info("validate update", "name", r.Name)
+func (b *Bundle) ValidateUpdate(old runtime.Object) error {
+	bundlelog.V(1).Info("validate update", "name", b.Name)
 
 	oldBundle := old.(*Bundle)
-	if err := checkImmutableSpec(oldBundle, r); err != nil {
+	if err := checkImmutableSpec(oldBundle, b); err != nil {
 		return err
 	}
 
-	return checkBundleSource(r)
+	return checkBundleSource(b)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (r *Bundle) ValidateDelete() error {
-	bundlelog.V(1).Info("validate delete", "name", r.Name)
+func (b *Bundle) ValidateDelete() error {
+	bundlelog.V(1).Info("validate delete", "name", b.Name)
 
 	return nil
 }

--- a/internal/provisioner/plain/controllers/bundle_controller.go
+++ b/internal/provisioner/plain/controllers/bundle_controller.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/finalizer"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	crsource "sigs.k8s.io/controller-runtime/pkg/source"
 
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	plain "github.com/operator-framework/rukpak/internal/provisioner/plain/types"
@@ -261,6 +262,7 @@ func getObjects(bundleFS fs.FS) ([]client.Object, error) {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *BundleReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	l := mgr.GetLogger().WithName("controller.bundle")
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&rukpakv1alpha1.Bundle{}, builder.WithPredicates(
 			util.BundleProvisionerFilter(plain.ProvisionerID),
@@ -268,7 +270,6 @@ func (r *BundleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// The default unpacker creates Pod's ownerref'd to its bundle, so
 		// we need to watch pods to ensure we reconcile events coming from these
 		// pods.
-		// TODO: Update provisioner pod handler to correctly check provisioner class mapping
-		Owns(&corev1.Pod{}).
+		Watches(&crsource.Kind{Type: &corev1.Pod{}}, util.MapOwneeToOwnerProvisionerHandler(context.TODO(), mgr.GetClient(), l, plain.ProvisionerID, &rukpakv1alpha1.Bundle{})).
 		Complete(r)
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -12,7 +12,9 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,6 +37,64 @@ func BundleInstanceProvisionerFilter(provisionerClassName string) predicate.Pred
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		b := obj.(*rukpakv1alpha1.BundleInstance)
 		return b.Spec.ProvisionerClassName == provisionerClassName
+	})
+}
+
+type ProvisionerClassNameGetter interface {
+	client.Object
+	ProvisionerClassName() string
+}
+
+// MapOwneeToOwnerProvisionerHandler is a handler implementation that finds an owner reference in the event object that
+// references the provided owner. If a reference for the provided owner is found AND that owner's provisioner class name
+// matches the provided provisionerClassName, this handler enqueues a request for that owner to be reconciled.
+func MapOwneeToOwnerProvisionerHandler(ctx context.Context, cl client.Client, log logr.Logger, provisionerClassName string, owner ProvisionerClassNameGetter) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(obj client.Object) []reconcile.Request {
+		gvks, unversioned, err := cl.Scheme().ObjectKinds(owner)
+		if err != nil {
+			log.Error(err, "get GVKs for owner")
+			return nil
+		}
+		if unversioned {
+			log.Error(err, "owner cannot be an unversioned type")
+			return nil
+		}
+
+		type ownerInfo struct {
+			key types.NamespacedName
+			gvk schema.GroupVersionKind
+		}
+		var oi *ownerInfo
+
+	refLoop:
+		for _, ref := range obj.GetOwnerReferences() {
+			gv, err := schema.ParseGroupVersion(ref.APIVersion)
+			if err != nil {
+				log.Error(err, fmt.Sprintf("parse group version %q", ref.APIVersion))
+				return nil
+			}
+			refGVK := gv.WithKind(ref.Kind)
+			for _, gvk := range gvks {
+				if refGVK == gvk && ref.Controller != nil && *ref.Controller {
+					oi = &ownerInfo{
+						key: types.NamespacedName{Name: ref.Name},
+						gvk: gvk,
+					}
+					break refLoop
+				}
+			}
+		}
+		if oi == nil {
+			return nil
+		}
+		if err := cl.Get(ctx, oi.key, owner); err != nil {
+			log.Error(err, "get owner", "kind", oi.gvk, "name", oi.key.Name)
+			return nil
+		}
+		if owner.ProvisionerClassName() != provisionerClassName {
+			return nil
+		}
+		return []reconcile.Request{{NamespacedName: oi.key}}
 	})
 }
 


### PR DESCRIPTION
Add a controller event handler implementation that maps events to reconciliation requests for owned objects that have the expected provisionerClassName field. 

This is used in place of the generic `handler.EnqueueRequestForOwner` implementation because it additionally considers the owner's provisioner class name. This extra consideration is important when multiple provisioners exist in a cluster and it is necessary for them to ignore events for owned objects that reference a bundle that is assigned to another provisioner class.

Reviewer note: I implemented the `MapOwneeToOwnerProvisionerHandler` function such that it would be trivial to use it for BundleInstance in the future if that need ever arises.

@timflannagan mentioned that while this approach does work, it _is_ fairly complex to implement. It requires looking up the owner object and checking its provisioner class name. I think we want to keep the owner reference on the unpack pods so that we get garbage collection for free when Bundles are deleted, but I do think it's worth considering whether there might be a better way to implement this mapping.

Closes #393 