### PR TITLE
Add HTTP storage Loader to enable loading of other provisioner's bundles

### DIFF
--- a/internal/provisioner/plain/controllers/bundle_controller.go
+++ b/internal/provisioner/plain/controllers/bundle_controller.go
@@ -57,6 +57,7 @@ type BundleReconciler struct {
 //+kubebuilder:rbac:groups=core.rukpak.io,resources=bundles,verbs=list;watch
 //+kubebuilder:rbac:groups=core.rukpak.io,resources=bundles/status,verbs=update;patch
 //+kubebuilder:rbac:groups=core.rukpak.io,resources=bundles/finalizers,verbs=update
+//+kubebuilder:rbac:verbs=get,urls=/bundles/*
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=list;watch;create;delete
 //+kubebuilder:rbac:groups=core,resources=pods/log,verbs=get
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create

--- a/internal/provisioner/plain/main.go
+++ b/internal/provisioner/plain/main.go
@@ -134,10 +134,18 @@ func main() {
 		setupLog.Error(err, "unable to parse bundle content server URL")
 		os.Exit(1)
 	}
-	bundleStorage := &storage.LocalDirectory{
+
+	localStorage := &storage.LocalDirectory{
 		RootDirectory: storageDirectory,
 		URL:           *storageURL,
 	}
+	httpLoader := storage.NewHTTP(
+		// TODO: Use a trusted CA to connect to bundle content URLs.
+		storage.WithInsecureSkipVerify(true),
+		storage.WithBearerToken(cfg.BearerToken),
+	)
+	bundleStorage := storage.WithFallbackLoader(localStorage, httpLoader)
+
 	// NOTE: AddMetricsExtraHandler isn't actually metrics-specific. We can run
 	// whatever handlers we want on the existing webserver that
 	// controller-runtime runs when MetricsBindAddress is configured on the

--- a/internal/storage/http.go
+++ b/internal/storage/http.go
@@ -1,0 +1,78 @@
+package storage
+
+import (
+	"compress/gzip"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"time"
+
+	"github.com/nlepage/go-tarfs"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+)
+
+type HTTP struct {
+	client      http.Client
+	requestOpts []func(*http.Request)
+}
+
+type HTTPOption func(*HTTP)
+
+func WithInsecureSkipVerify(v bool) HTTPOption {
+	return func(s *HTTP) {
+		tr := s.client.Transport.(*http.Transport)
+		if tr.TLSClientConfig == nil {
+			tr.TLSClientConfig = &tls.Config{}
+		}
+		tr.TLSClientConfig.InsecureSkipVerify = v
+	}
+}
+
+func WithBearerToken(token string) HTTPOption {
+	return func(s *HTTP) {
+		s.requestOpts = append(s.requestOpts, func(request *http.Request) {
+			request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+		})
+	}
+}
+
+type HTTPRequestOption func(*http.Request)
+
+func NewHTTP(opts ...HTTPOption) *HTTP {
+	s := &HTTP{client: http.Client{
+		Timeout:   time.Minute,
+		Transport: http.DefaultTransport.(*http.Transport).Clone(),
+	}}
+	for _, f := range opts {
+		f(s)
+	}
+	return s
+}
+
+func (s *HTTP) Load(ctx context.Context, owner client.Object) (fs.FS, error) {
+	bundle := owner.(*rukpakv1alpha1.Bundle)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, bundle.Status.ContentURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range s.requestOpts {
+		f(req)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected response status %q", resp.Status)
+	}
+	tarReader, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return tarfs.New(tarReader)
+}

--- a/internal/storage/http_test.go
+++ b/internal/storage/http_test.go
@@ -1,0 +1,134 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	"github.com/operator-framework/rukpak/internal/util"
+)
+
+var _ = Describe("HTTP", func() {
+	var (
+		ctx        context.Context
+		bundle     *rukpakv1alpha1.Bundle
+		testFS     fs.FS
+		localStore *LocalDirectory
+		server     *httptest.Server
+	)
+	BeforeEach(func() {
+		ctx = context.Background()
+		bundle = &rukpakv1alpha1.Bundle{ObjectMeta: metav1.ObjectMeta{
+			Name: util.GenerateBundleName("testbundle", rand.String(8)),
+		}}
+
+		// Generate a test FS to represent the bundle.
+		testFS = generateFS()
+
+		// Create a test directory to store bundles.
+		testDir := filepath.Join(GinkgoT().TempDir(), rand.String(8))
+		Expect(os.MkdirAll(testDir, 0700)).To(Succeed())
+
+		// Setup the local store and store the generated FS.
+		localStore = &LocalDirectory{RootDirectory: testDir}
+		Expect(localStore.Store(ctx, bundle, testFS)).To(Succeed())
+
+		// Create and start the server
+		server = newTLSServer(localStore, "abc123")
+
+		// Populate the content URL, this has to happen after the server has
+		// started so that we know the server's base URL.
+		contentURL, err := localStore.URLFor(ctx, bundle)
+		Expect(err).To(BeNil())
+		bundle.Status.ContentURL = contentURL
+	})
+	AfterEach(func() {
+		server.Close()
+		Expect(os.RemoveAll(localStore.RootDirectory)).To(Succeed())
+	})
+	Context("with insecure skip verify disabled", func() {
+		var opts []HTTPOption
+		BeforeEach(func() {
+			opts = append(opts, WithInsecureSkipVerify(false))
+		})
+
+		It("should get a certificate verification error", func() {
+			store := NewHTTP(opts...)
+			loadedTestFS, err := store.Load(ctx, bundle)
+			Expect(loadedTestFS).To(BeNil())
+			Expect(err).To(MatchError(Or(
+				ContainSubstring("certificate is not trusted"),              // works on darwin
+				ContainSubstring("certificate signed by unknown authority"), // works on linux
+			)))
+		})
+	})
+	Context("with insecure skip verify enabled", func() {
+		var opts []HTTPOption
+		BeforeEach(func() {
+			opts = append(opts, WithInsecureSkipVerify(true))
+		})
+		Context("with correct bearer token", func() {
+			BeforeEach(func() {
+				opts = append(opts, WithBearerToken("abc123"))
+			})
+			Context("with existing bundle", func() {
+				It("should succeed", func() {
+					store := NewHTTP(opts...)
+					loadedTestFS, err := store.Load(ctx, bundle)
+					Expect(fsEqual(testFS, loadedTestFS)).To(BeTrue())
+					Expect(err).To(BeNil())
+				})
+			})
+			Context("with non-existing bundle", func() {
+				BeforeEach(func() {
+					bundle.Status.ContentURL += "foobar"
+				})
+				It("should get 404 not found error", func() {
+					store := NewHTTP(opts...)
+					loadedTestFS, err := store.Load(ctx, bundle)
+					Expect(loadedTestFS).To(BeNil())
+					Expect(err).To(MatchError(ContainSubstring("404 Not Found")))
+				})
+			})
+		})
+		Context("with incorrect bearer token", func() {
+			BeforeEach(func() {
+				opts = append(opts, WithBearerToken("xyz789"))
+			})
+			It("should get a 401 Unauthorized error", func() {
+				store := NewHTTP(opts...)
+				loadedTestFS, err := store.Load(ctx, bundle)
+				Expect(loadedTestFS).To(BeNil())
+				Expect(err).To(MatchError(ContainSubstring("401 Unauthorized")))
+			})
+		})
+	})
+})
+
+func newTLSServer(localStore *LocalDirectory, bearerToken string) *httptest.Server {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		if req.Header.Get("Authorization") != fmt.Sprintf("Bearer %s", bearerToken) {
+			resp.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		localStore.ServeHTTP(resp, req)
+	}))
+	localStore.URL = url.URL{
+		Scheme: "https",
+		Host:   strings.TrimPrefix(server.URL, "https://"),
+		Path:   "/",
+	}
+	return server
+}

--- a/internal/storage/localdir_test.go
+++ b/internal/storage/localdir_test.go
@@ -1,4 +1,4 @@
-package storage_test
+package storage
 
 import (
 	"context"
@@ -18,14 +18,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
-	"github.com/operator-framework/rukpak/internal/storage"
 )
 
 var _ = Describe("LocalDirectory", func() {
 	var (
 		ctx    context.Context
 		owner  *rukpakv1alpha1.Bundle
-		store  storage.LocalDirectory
+		store  LocalDirectory
 		testFS fs.FS
 	)
 
@@ -37,7 +36,7 @@ var _ = Describe("LocalDirectory", func() {
 				UID:  types.UID(rand.String(8)),
 			},
 		}
-		store = storage.LocalDirectory{RootDirectory: GinkgoT().TempDir()}
+		store = LocalDirectory{RootDirectory: GinkgoT().TempDir()}
 		testFS = generateFS()
 	})
 	When("a bundle is not stored", func() {
@@ -133,7 +132,7 @@ func fsEqual(a, b fs.FS) (bool, error) {
 			m[path] = &fstest.MapFile{
 				Data:    data,
 				Mode:    d.Type(),
-				ModTime: info.ModTime(),
+				ModTime: info.ModTime().UTC(),
 			}
 			return nil
 		}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -9,10 +9,38 @@ import (
 )
 
 type Storage interface {
+	Loader
+	Storer
+}
+
+type Loader interface {
 	Load(ctx context.Context, owner client.Object) (fs.FS, error)
+}
+
+type Storer interface {
 	Store(ctx context.Context, owner client.Object, bundle fs.FS) error
 	Delete(ctx context.Context, owner client.Object) error
 
 	http.Handler
 	URLFor(ctx context.Context, owner client.Object) (string, error)
+}
+
+type fallbackLoaderStorage struct {
+	Storage
+	fallbackLoader Loader
+}
+
+func WithFallbackLoader(s Storage, fallback Loader) Storage {
+	return &fallbackLoaderStorage{
+		Storage:        s,
+		fallbackLoader: fallback,
+	}
+}
+
+func (s *fallbackLoaderStorage) Load(ctx context.Context, owner client.Object) (fs.FS, error) {
+	fsys, err := s.Storage.Load(ctx, owner)
+	if err != nil {
+		return s.fallbackLoader.Load(ctx, owner)
+	}
+	return fsys, nil
 }

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1,0 +1,81 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	"github.com/operator-framework/rukpak/internal/util"
+)
+
+var _ = Describe("WithFallbackLoader", func() {
+	var (
+		ctx            context.Context
+		primaryBundle  *rukpakv1alpha1.Bundle
+		fallbackBundle *rukpakv1alpha1.Bundle
+		primaryStore   *LocalDirectory
+		fallbackStore  *LocalDirectory
+		primaryFS      fs.FS
+		fallbackFS     fs.FS
+
+		store Storage
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		primaryBundle = &rukpakv1alpha1.Bundle{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: util.GenerateBundleName("primary", rand.String(8)),
+			},
+		}
+		fallbackBundle = &rukpakv1alpha1.Bundle{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: util.GenerateBundleName("fallback", rand.String(8)),
+			},
+		}
+		primaryDir := filepath.Join(GinkgoT().TempDir(), fmt.Sprintf("primary-%s", rand.String(8)))
+		Expect(os.MkdirAll(primaryDir, 0700)).To(Succeed())
+		fallbackDir := filepath.Join(GinkgoT().TempDir(), fmt.Sprintf("fallback-%s", rand.String(8)))
+		Expect(os.MkdirAll(fallbackDir, 0700)).To(Succeed())
+
+		primaryStore = &LocalDirectory{RootDirectory: primaryDir}
+		primaryFS = generateFS()
+		Expect(primaryStore.Store(ctx, primaryBundle, primaryFS)).To(Succeed())
+
+		fallbackStore = &LocalDirectory{RootDirectory: fallbackDir}
+		fallbackFS = generateFS()
+		Expect(fallbackStore.Store(ctx, fallbackBundle, fallbackFS)).To(Succeed())
+
+		store = WithFallbackLoader(primaryStore, fallbackStore)
+	})
+
+	It("should find primary bundle", func() {
+		loadedTestFS, err := store.Load(ctx, primaryBundle)
+		Expect(err).To(BeNil())
+		Expect(fsEqual(primaryFS, loadedTestFS))
+	})
+	It("should find fallback bundle", func() {
+		loadedTestFS, err := store.Load(ctx, fallbackBundle)
+		Expect(err).To(BeNil())
+		Expect(fsEqual(fallbackFS, loadedTestFS))
+	})
+	It("should fail to find unknown bundle", func() {
+		unknownBundle := &rukpakv1alpha1.Bundle{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: util.GenerateBundleName("unknown", rand.String(8)),
+			},
+		}
+		loadedTestFS, err := store.Load(ctx, unknownBundle)
+		Expect(err).To(WithTransform(func(err error) bool { return errors.Is(err, os.ErrNotExist) }, BeTrue()))
+		Expect(loadedTestFS).To(BeNil())
+	})
+})

--- a/manifests/provisioners/plain/resources/cluster_role.yaml
+++ b/manifests/provisioners/plain/resources/cluster_role.yaml
@@ -6,6 +6,10 @@ metadata:
   creationTimestamp: null
   name: plain-provisioner-admin
 rules:
+- nonResourceURLs:
+  - /bundles/*
+  verbs:
+  - get
 - apiGroups:
   - '*'
   resources:


### PR DESCRIPTION
When multiple provisioners exist, it will be possible for a bundle instance with provisioner class name "foo" to embed a bundle with provisioner class name "bar". In this case, the "foo" bundle instance provisioner will need to be able to load the bundle content of the "bar" bundle, whose storage is handled by another provisioner.

This PR enables the "foo" provisioner to fallback to loading a bundle via its `status.contentURL` if it experiences an error loading that bundle from its storage.

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>