### PR TITLE
consolidate unpacker initialization; other minor provisioner main.go cleanups

### DIFF
--- a/internal/provisioner/registry/main.go
+++ b/internal/provisioner/registry/main.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -94,25 +93,21 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	setupLog.Info("starting up the provisioner", "git commit", version.String(), "unpacker image", unpackImage)
 
-	cfg := ctrl.GetConfigOrDie()
-	kubeClient, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		setupLog.Error(err, "unable to create kubernetes client")
-		os.Exit(1)
-	}
 	dependentRequirement, err := labels.NewRequirement(util.CoreOwnerKindKey, selection.In, []string{rukpakv1alpha1.BundleKind, rukpakv1alpha1.BundleInstanceKind})
 	if err != nil {
 		setupLog.Error(err, "unable to create dependent label selector for cache")
 		os.Exit(1)
 	}
 	dependentSelector := labels.NewSelector().Add(*dependentRequirement)
+
+	cfg := ctrl.GetConfigOrDie()
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     httpBindAddr,
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "510f803c.olm.operatorframework.io",
+		LeaderElectionID:       "registry.core.rukpak.io",
 		NewCache: cache.BuilderWithOptions(cache.Options{
 			SelectorsByObject: cache.SelectorsByObject{
 				&rukpakv1alpha1.BundleInstance{}: {},
@@ -184,16 +179,11 @@ func main() {
 	}
 
 	const registryBundleProvisionerName = "registry"
-	unpacker := source.NewUnpacker(map[rukpakv1alpha1.SourceType]source.Unpacker{
-		rukpakv1alpha1.SourceTypeImage: &source.Image{
-			Client:          mgr.GetClient(),
-			KubeClient:      kubeClient,
-			ProvisionerName: registryBundleProvisionerName,
-			PodNamespace:    ns,
-			UnpackImage:     unpackImage,
-		},
-		rukpakv1alpha1.SourceTypeGit: &source.Git{},
-	})
+	unpacker, err := source.NewDefaultUnpacker(mgr, ns, registryBundleProvisionerName, unpackImage)
+	if err != nil {
+		setupLog.Error(err, "unable to setup bundle unpacker")
+		os.Exit(1)
+	}
 
 	if err = (&controllers.BundleReconciler{
 		Client:     mgr.GetClient(),


### PR DESCRIPTION
The changes from #387 and #366 had some minor conflicts at the time they we're being authored because of code duplication around the setup of the unpacker.

This PR consolidates the unpacker initialization into a separate function, which will help us de-deduplicate code, avoid a similar situation in the future.

I've also been playing with a PVC source type, and I noticed that the addition of more sources will lead to even more duplication unless we consolidate.