### PR TITLE
e2e add private image source test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ PKGS = $(shell go list ./...)
 export CERT_MGR_VERSION ?= v1.7.1
 RUKPAK_NAMESPACE ?= rukpak-system
 
+REGISTRY_NAME="docker-registry"
+REGISTRY_NAMESPACE=rukpak-e2e
+DNS_NAME=$(REGISTRY_NAME).$(REGISTRY_NAMESPACE).svc.cluster.local
+
 CONTAINER_RUNTIME ?= docker
 
 # kernel-style V=1 build verbosity
@@ -89,7 +93,7 @@ test-e2e: ginkgo ## Run the e2e tests
 	$(GINKGO) -trace -progress $(FOCUS) test/e2e
 
 e2e: KIND_CLUSTER_NAME=rukpak-e2e
-e2e: run image-registry kind-load-bundles test-e2e kind-cluster-cleanup ## Run e2e tests against an ephemeral kind cluster
+e2e: run image-registry kind-load-bundles registry-load-bundles test-e2e kind-cluster-cleanup ## Run e2e tests against an ephemeral kind cluster
 
 kind-cluster: kind kind-cluster-cleanup ## Standup a kind cluster
 	$(KIND) create cluster --name ${KIND_CLUSTER_NAME}
@@ -183,8 +187,9 @@ kind-load-bundles: kind ## Load the e2e testdata container images into a kind cl
 kind-load: kind ## Loads the currently constructed image onto the cluster
 	$(KIND) load docker-image $(IMAGE) --name $(KIND_CLUSTER_NAME)
 
-registry-load-bundles: kind-load-bundles ## Load the e2e testdata container images into registry
-	./tools/imageregistry/load_test_image.sh
+registry-load-bundles: ## Load selected e2e testdata container images created in kind-load-bundles into registry
+	$(CONTAINER_RUNTIME) tag testdata/bundles/plain-v0:valid $(DNS_NAME):5000/bundles/plain-v0:valid
+	./tools/imageregistry/load_test_image.sh $(KIND) $(KIND_CLUSTER_NAME)
 
 ###########
 # Release #

--- a/tools/imageregistry/load_test_image.sh
+++ b/tools/imageregistry/load_test_image.sh
@@ -3,13 +3,16 @@
 export REGISTRY_NAME="docker-registry"
 export REGISTRY_NAMESPACE=rukpak-e2e
 export DNS_NAME=$REGISTRY_NAME.$REGISTRY_NAMESPACE.svc.cluster.local
+KIND=$1
+KIND_CLUSTER_NAME=$2
 
 # push test bundle image into in-cluster docker registry
 kubectl exec nerdctl -n $REGISTRY_NAMESPACE -- sh -c "nerdctl login -u myuser -p mypasswd $DNS_NAME:5000 --insecure-registry"
 
-for x in $(docker images --format "{{.Repository}}:{{.Tag}}" | grep testdata); do
-    kubectl exec nerdctl -n $REGISTRY_NAMESPACE -- sh -c "nerdctl -n k8s.io tag $x $DNS_NAME:5000${x##testdata}"
-    kubectl exec nerdctl -n $REGISTRY_NAMESPACE -- sh -c "nerdctl -n k8s.io push $DNS_NAME:5000${x##testdata} --insecure-registry"
-    kubectl exec nerdctl -n $REGISTRY_NAMESPACE -- sh -c "nerdctl -n k8s.io rmi $DNS_NAME:5000${x##testdata} --insecure-registry"
+for x in $(docker images --format "{{.Repository}}:{{.Tag}}" | grep $DNS_NAME); do
+echo $x
+    $KIND load docker-image $x --name $KIND_CLUSTER_NAME
+    kubectl exec nerdctl -n $REGISTRY_NAMESPACE -- sh -c "nerdctl -n k8s.io push $x --insecure-registry"
+    kubectl exec nerdctl -n $REGISTRY_NAMESPACE -- sh -c "nerdctl -n k8s.io rmi $x --insecure-registry"
 done
 

--- a/tools/imageregistry/setup_imageregistry.sh
+++ b/tools/imageregistry/setup_imageregistry.sh
@@ -47,5 +47,6 @@ echo IMAGE_PULL_RECRET $IMAGE_PULL_RECRET
 
 # clean up 
 rm -rf /tmp/var/imageregistry/certs
-
+kubectl wait --for=condition=ContainersReady --namespace=rukpak-e2e pod/docker-registry-pod --timeout=60s
+kubectl wait --for=condition=ContainersReady --namespace=rukpak-e2e pod/nerdctl --timeout=60s
 


### PR DESCRIPTION
Signed-off-by: akihikokuroda <akuroda@us.ibm.com>

Closes #381 

This PR adds one e2e test that access to the in-cluster registry with its credential information. 