### PR TITLE
enable more linters; disable required error wrapping

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,23 +5,30 @@ run:
 linters:
   enable:
   - asciicheck
+  - bodyclose
   - deadcode
   - depguard
   - errorlint
   - gofmt
   - goimports
   - importas
-  - prealloc
-  - nestif
-  - revive
   - misspell
+  - nestif
+  - nonamedreturns
+  - prealloc
+  - revive
   - stylecheck
   - tparallel
   - unconvert
   - unparam
+  - unused
+  - varcheck
   - whitespace
 
 linters-settings:
+  errorlint:
+    errorf: false
+
   importas:
     alias:
     - pkg: k8s.io/api/core/v1
@@ -34,6 +41,7 @@ linters-settings:
       alias: rukpakv1alpha1
   goimports:
     local-prefixes: github.com/operator-framework/rukpak
+
 
 output:
   format: tab

--- a/cmd/crdvalidator/handlers/crd.go
+++ b/cmd/crdvalidator/handlers/crd.go
@@ -54,7 +54,7 @@ func (cv *CrdValidator) Handle(ctx context.Context, req admission.Request) admis
 	if err := cv.decoder.Decode(req, incomingCrd); err != nil {
 		message := fmt.Sprintf("failed to decode CRD %q", req.Name)
 		cv.log.V(0).Error(err, message)
-		return admission.Errored(http.StatusBadRequest, fmt.Errorf("%s: %w", message, err))
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("%s: %v", message, err))
 	}
 
 	// Check if the request should get validated

--- a/cmd/crdvalidator/main.go
+++ b/cmd/crdvalidator/main.go
@@ -19,8 +19,7 @@ package main
 import (
 	"os"
 
-	"github.com/operator-framework/rukpak/cmd/crdvalidator/handlers"
-
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -28,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"github.com/operator-framework/rukpak/cmd/crdvalidator/handlers"
 )
 
 var (

--- a/cmd/unpack/main.go
+++ b/cmd/unpack/main.go
@@ -66,12 +66,12 @@ func main() {
 				}
 				info, err := d.Info()
 				if err != nil {
-					return fmt.Errorf("get file info for %q: %w", path, err)
+					return fmt.Errorf("get file info for %q: %v", path, err)
 				}
 
 				h, err := tar.FileInfoHeader(info, "")
 				if err != nil {
-					return fmt.Errorf("build tar file info header for %q: %w", path, err)
+					return fmt.Errorf("build tar file info header for %q: %v", path, err)
 				}
 				h.Uid = 0
 				h.Gid = 0
@@ -80,17 +80,17 @@ func main() {
 				h.Name = path
 
 				if err := tw.WriteHeader(h); err != nil {
-					return fmt.Errorf("write tar header for %q: %w", path, err)
+					return fmt.Errorf("write tar header for %q: %v", path, err)
 				}
 				if d.IsDir() {
 					return nil
 				}
 				f, err := bundleFS.Open(path)
 				if err != nil {
-					return fmt.Errorf("open file %q: %w", path, err)
+					return fmt.Errorf("open file %q: %v", path, err)
 				}
 				if _, err := io.Copy(tw, f); err != nil {
-					return fmt.Errorf("write tar data for %q: %w", path, err)
+					return fmt.Errorf("write tar data for %q: %v", path, err)
 				}
 				return nil
 			}); err != nil {

--- a/internal/convert/registryv1.go
+++ b/internal/convert/registryv1.go
@@ -77,7 +77,7 @@ func RegistryV1ToPlain(rv1 fs.FS) (fs.FS, error) {
 				break
 			}
 			if err != nil {
-				return nil, fmt.Errorf("read %q: %w", e.Name(), err)
+				return nil, fmt.Errorf("read %q: %v", e.Name(), err)
 			}
 			objects = append(objects, &obj)
 		}

--- a/internal/provisioner/plain/controllers/bundleinstance_controller.go
+++ b/internal/provisioner/plain/controllers/bundleinstance_controller.go
@@ -426,12 +426,12 @@ func (r *BundleInstanceReconciler) getReleaseState(cl helmclient.ActionInterface
 func (r *BundleInstanceReconciler) loadBundle(ctx context.Context, bundle *rukpakv1alpha1.Bundle, biName string) ([]client.Object, error) {
 	bundleFS, err := r.BundleStorage.Load(ctx, bundle)
 	if err != nil {
-		return nil, fmt.Errorf("load bundle: %w", err)
+		return nil, fmt.Errorf("load bundle: %v", err)
 	}
 
 	objects, err := getObjects(bundleFS)
 	if err != nil {
-		return nil, fmt.Errorf("read bundle objects from bundle: %w", err)
+		return nil, fmt.Errorf("read bundle objects from bundle: %v", err)
 	}
 
 	objs := make([]client.Object, 0, len(objects))

--- a/internal/source/git.go
+++ b/internal/source/git.go
@@ -70,11 +70,11 @@ func (r *Git) Unpack(ctx context.Context, bundle *rukpakv1alpha1.Bundle) (*Resul
 	// Clone
 	repo, err := git.CloneContext(ctx, memory.NewStorage(), memfs.New(), &cloneOpts)
 	if err != nil {
-		return nil, fmt.Errorf("bundle unpack git clone error: %w - %s", err, progress.String())
+		return nil, fmt.Errorf("bundle unpack git clone error: %v - %s", err, progress.String())
 	}
 	wt, err := repo.Worktree()
 	if err != nil {
-		return nil, fmt.Errorf("bundle unpack error: %w", err)
+		return nil, fmt.Errorf("bundle unpack error: %v", err)
 	}
 
 	// Checkout commit
@@ -84,7 +84,7 @@ func (r *Git) Unpack(ctx context.Context, bundle *rukpakv1alpha1.Bundle) (*Resul
 			Commit: commitHash,
 			Mode:   git.HardReset,
 		}); err != nil {
-			return nil, fmt.Errorf("checkout commit %q: %w", commitHash.String(), err)
+			return nil, fmt.Errorf("checkout commit %q: %v", commitHash.String(), err)
 		}
 	}
 
@@ -98,7 +98,7 @@ func (r *Git) Unpack(ctx context.Context, bundle *rukpakv1alpha1.Bundle) (*Resul
 		}
 		sub, err := wt.Filesystem.Chroot(filepath.Clean(directory))
 		if err != nil {
-			return nil, fmt.Errorf("get subdirectory %q for repository %q: %w", gitsource.Directory, gitsource.Repository, err)
+			return nil, fmt.Errorf("get subdirectory %q for repository %q: %v", gitsource.Directory, gitsource.Repository, err)
 		}
 		bundleFS = &billyFS{sub}
 	}

--- a/internal/source/image.go
+++ b/internal/source/image.go
@@ -120,7 +120,7 @@ func pendingImagePodResult(pod *corev1.Pod) *Result {
 func (i *Image) failedPodResult(ctx context.Context, pod *corev1.Pod) error {
 	logs, err := i.getPodLogs(ctx, pod)
 	if err != nil {
-		return fmt.Errorf("unpack failed: failed to retrieve failed pod logs: %w", err)
+		return fmt.Errorf("unpack failed: failed to retrieve failed pod logs: %v", err)
 	}
 	_ = i.Client.Delete(ctx, pod)
 	return fmt.Errorf("unpack failed: %v", string(logs))
@@ -129,12 +129,12 @@ func (i *Image) failedPodResult(ctx context.Context, pod *corev1.Pod) error {
 func (i *Image) succeededPodResult(ctx context.Context, pod *corev1.Pod) (*Result, error) {
 	bundleFS, err := i.getBundleContents(ctx, pod)
 	if err != nil {
-		return nil, fmt.Errorf("get bundle contents: %w", err)
+		return nil, fmt.Errorf("get bundle contents: %v", err)
 	}
 
 	digest, err := i.getBundleImageDigest(pod)
 	if err != nil {
-		return nil, fmt.Errorf("get bundle image digest: %w", err)
+		return nil, fmt.Errorf("get bundle image digest: %v", err)
 	}
 
 	resolvedSource := &rukpakv1alpha1.BundleSource{
@@ -148,19 +148,19 @@ func (i *Image) succeededPodResult(ctx context.Context, pod *corev1.Pod) (*Resul
 func (i *Image) getBundleContents(ctx context.Context, pod *corev1.Pod) (fs.FS, error) {
 	bundleData, err := i.getPodLogs(ctx, pod)
 	if err != nil {
-		return nil, fmt.Errorf("get bundle contents: %w", err)
+		return nil, fmt.Errorf("get bundle contents: %v", err)
 	}
 	bd := struct {
 		Content []byte `json:"content"`
 	}{}
 
 	if err := json.Unmarshal(bundleData, &bd); err != nil {
-		return nil, fmt.Errorf("parse bundle data: %w", err)
+		return nil, fmt.Errorf("parse bundle data: %v", err)
 	}
 
 	gzr, err := gzip.NewReader(bytes.NewReader(bd.Content))
 	if err != nil {
-		return nil, fmt.Errorf("read bundle content gzip: %w", err)
+		return nil, fmt.Errorf("read bundle content gzip: %v", err)
 	}
 	return tarfs.New(gzr)
 }
@@ -177,7 +177,7 @@ func (i *Image) getBundleImageDigest(pod *corev1.Pod) (string, error) {
 func (i *Image) getPodLogs(ctx context.Context, pod *corev1.Pod) ([]byte, error) {
 	logReader, err := i.KubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{}).Stream(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("get pod logs: %w", err)
+		return nil, fmt.Errorf("get pod logs: %v", err)
 	}
 	defer logReader.Close()
 	buf := &bytes.Buffer{}

--- a/internal/storage/localdir.go
+++ b/internal/storage/localdir.go
@@ -54,12 +54,12 @@ func (s *LocalDirectory) Store(_ context.Context, owner client.Object, bundle fs
 		}
 		info, err := d.Info()
 		if err != nil {
-			return fmt.Errorf("get file info for %q: %w", path, err)
+			return fmt.Errorf("get file info for %q: %v", path, err)
 		}
 
 		h, err := tar.FileInfoHeader(info, "")
 		if err != nil {
-			return fmt.Errorf("build tar file info header for %q: %w", path, err)
+			return fmt.Errorf("build tar file info header for %q: %v", path, err)
 		}
 		h.Uid = 0
 		h.Gid = 0
@@ -68,21 +68,21 @@ func (s *LocalDirectory) Store(_ context.Context, owner client.Object, bundle fs
 		h.Name = path
 
 		if err := tw.WriteHeader(h); err != nil {
-			return fmt.Errorf("write tar header for %q: %w", path, err)
+			return fmt.Errorf("write tar header for %q: %v", path, err)
 		}
 		if d.IsDir() {
 			return nil
 		}
 		f, err := bundle.Open(path)
 		if err != nil {
-			return fmt.Errorf("open file %q: %w", path, err)
+			return fmt.Errorf("open file %q: %v", path, err)
 		}
 		if _, err := io.Copy(tw, f); err != nil {
-			return fmt.Errorf("write tar data for %q: %w", path, err)
+			return fmt.Errorf("write tar data for %q: %v", path, err)
 		}
 		return nil
 	}); err != nil {
-		return fmt.Errorf("generate tar.gz for bundle %q: %w", owner.GetName(), err)
+		return fmt.Errorf("generate tar.gz for bundle %q: %v", owner.GetName(), err)
 	}
 	if err := tw.Close(); err != nil {
 		return err

--- a/internal/unit/unit.go
+++ b/internal/unit/unit.go
@@ -12,12 +12,12 @@ func SetupClient() (client.Client, error) {
 
 	config, err := testenv.Start()
 	if err != nil {
-		return nil, fmt.Errorf("failed to start envtest: %w", err)
+		return nil, fmt.Errorf("failed to start envtest: %v", err)
 	}
 
 	kubeclient, err := client.New(config, client.Options{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create kubeclient: %w", err)
+		return nil, fmt.Errorf("failed to create kubeclient: %v", err)
 	}
 
 	return kubeclient, nil

--- a/internal/updater/bundle-instance/updater_suite_test.go
+++ b/internal/updater/bundle-instance/updater_suite_test.go
@@ -1,10 +1,10 @@
 package bundleinstance
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestUpdater(t *testing.T) {

--- a/internal/updater/bundle/updater_suite_test.go
+++ b/internal/updater/bundle/updater_suite_test.go
@@ -1,10 +1,10 @@
 package bundle
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestUpdater(t *testing.T) {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -152,7 +152,7 @@ func GetBundlesForBundleInstanceSelector(ctx context.Context, c client.Client, b
 	if err := c.List(ctx, bundleList, &client.ListOptions{
 		LabelSelector: selector,
 	}); err != nil {
-		return nil, fmt.Errorf("failed to list bundles using the %s selector: %w", selector.String(), err)
+		return nil, fmt.Errorf("failed to list bundles using the %s selector: %v", selector.String(), err)
 	}
 	return bundleList, nil
 }
@@ -277,7 +277,7 @@ func CreateOrRecreate(ctx context.Context, cl client.Client, obj client.Object, 
 		return controllerutil.OperationResultNone, nil
 	}
 
-	if err := wait.PollImmediateUntil(time.Millisecond*5, func() (done bool, err error) {
+	if err := wait.PollImmediateUntil(time.Millisecond*5, func() (bool, error) {
 		if err := cl.Delete(ctx, obj); err != nil {
 			if apierrors.IsNotFound(err) {
 				return true, nil


### PR DESCRIPTION
Disabling `errorlint`'s configuration that enforces all errors to be wrapped. Motivation: https://go.dev/blog/go1.13-errors#whether-to-wrap

Also adding some new, seemingly low-impact linters:
- bodyclose - checks whether HTTP response body is closed successfully
- misspell - Finds commonly misspelled English words in comments
- nonamedreturns - Reports all named returns (see discussion [here](https://github.com/operator-framework/rukpak/pull/407#discussion_r887182505))
- unused - Checks Go code for unused constants, variables, functions and types
- varcheck - Finds unused global variables and constants