### PR TITLE
api: Change BundleInstance status.installedBundleName to status.activeBundle

### DIFF
--- a/api/v1alpha1/bundledeployment_types.go
+++ b/api/v1alpha1/bundledeployment_types.go
@@ -64,14 +64,14 @@ type BundleTemplate struct {
 
 // BundleDeploymentStatus defines the observed state of BundleDeployment
 type BundleDeploymentStatus struct {
-	Conditions          []metav1.Condition `json:"conditions,omitempty"`
-	InstalledBundleName string             `json:"installedBundleName,omitempty"`
+	Conditions   []metav1.Condition `json:"conditions,omitempty"`
+	ActiveBundle string             `json:"activeBundle,omitempty"`
 }
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:scope=Cluster,shortName={"bd","bds"}
-//+kubebuilder:printcolumn:name="Installed Bundle",type=string,JSONPath=`.status.installedBundleName`
+//+kubebuilder:printcolumn:name="Active Bundle",type=string,JSONPath=`.status.activeBundle`
 //+kubebuilder:printcolumn:name="Install State",type=string,JSONPath=`.status.conditions[?(.type=="Installed")].reason`
 //+kubebuilder:printcolumn:name=Age,type=date,JSONPath=`.metadata.creationTimestamp`
 

--- a/internal/provisioner/plain/README.md
+++ b/internal/provisioner/plain/README.md
@@ -69,8 +69,8 @@ InstallationSucceeded Phase if the application of resources to the cluster was s
 
 ```console
 $ kubectl get bundledeployment my-bundle-deployment
-NAME                 DESIRED BUNDLE   INSTALLED BUNDLE   INSTALL STATE           AGE
-my-bundle-deployment   my-bundle        my-bundle          InstallationSucceeded   11s
+NAME                   ACTIVE BUNDLE    INSTALL STATE           AGE
+my-bundle-deployment   my-bundle        InstallationSucceeded   11s
 ```
 
 > Note: Creation of more than one BundleDeployment from the same Bundle will likely result in an error.
@@ -154,7 +154,7 @@ A successful installation will show InstallationSucceeded as the `INSTALL STATE`
 
 ```console
 $ kubectl get bundledeployment combo
-NAME    INSTALLED BUNDLE   INSTALL STATE           AGE
+NAME    ACTIVE BUNDLE      INSTALL STATE           AGE
 combo   combo-7cdc7d7d6d   InstallationSucceeded   10s
 ```
 
@@ -242,7 +242,7 @@ NAME               TYPE    PHASE      AGE
 combo-7ddfd9fcd5   image   Unpacked   10s
 
 $ kubectl get bundledeployment combo
-NAME    INSTALLED BUNDLE   INSTALL STATE           AGE
+NAME    ACTIVE BUNDLE      INSTALL STATE           AGE
 combo   combo-7ddfd9fcd5   InstallationSucceeded   10s
 
 $ kubectl -n combo get deployment

--- a/internal/provisioner/registry/README.md
+++ b/internal/provisioner/registry/README.md
@@ -76,8 +76,8 @@ InstallationSucceeded Phase if the application of resources to the cluster was s
 
 ```console
 $ kubectl get bundledeployment my-bundle-deployment
-NAME                   DESIRED BUNDLE   INSTALLED BUNDLE   INSTALL STATE           AGE
-my-bundle-deployment   my-bundle        my-bundle          InstallationSucceeded   11s
+NAME                   ACTIVE BUNDLE      INSTALL STATE           AGE
+my-bundle-deployment   my-bundle          InstallationSucceeded   11s
 ```
 
 > Note: Creation of more than one BundleDeployment from the same Bundle will likely result in an error.
@@ -161,7 +161,7 @@ A successful installation will show InstallationSucceeded as the `INSTALL STATE`
 
 ```console
 $ kubectl get bundledeployment prometheus
-NAME         INSTALLED BUNDLE        INSTALL STATE           AGE
+NAME         ACTIVE BUNDLE           INSTALL STATE           AGE
 prometheus   prometheus-5699cbff6    InstallationSucceeded   10s
 ```
 
@@ -246,10 +246,10 @@ NAME                    TYPE    PHASE      AGE
 prometheus-7f4f468d94   image   Unpacked   2m15s
 
 $ kubectl get bundledeployment prometheus
-NAME         INSTALLED BUNDLE        INSTALL STATE           AGE
+NAME         ACTIVE BUNDLE           INSTALL STATE           AGE
 prometheus   prometheus-7f4f468d94   InstallationSucceeded   2m47s
 
-$ kubectl -n prometheus-system get BundleDeployment
+$ kubectl -n prometheus-system get bundledeployment
 NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
 prometheus-operator   1/1     1            1           3m6s
 ```

--- a/internal/updater/bundle-deployment/updater.go
+++ b/internal/updater/bundle-deployment/updater.go
@@ -62,10 +62,10 @@ func EnsureCondition(condition metav1.Condition) UpdateStatusFunc {
 
 func EnsureInstalledName(bundleName string) UpdateStatusFunc {
 	return func(status *rukpakv1alpha1.BundleDeploymentStatus) bool {
-		if status.InstalledBundleName == bundleName {
+		if status.ActiveBundle == bundleName {
 			return false
 		}
-		status.InstalledBundleName = bundleName
+		status.ActiveBundle = bundleName
 		return true
 	}
 }

--- a/internal/updater/bundle-deployment/updater_test.go
+++ b/internal/updater/bundle-deployment/updater_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Updater", func() {
 		u      bundledeployment.Updater
 		obj    *rukpakv1alpha1.BundleDeployment
 		status = &rukpakv1alpha1.BundleDeploymentStatus{
-			InstalledBundleName: "bundle",
+			ActiveBundle: "bundle",
 			Conditions: []metav1.Condition{
 				{
 					Type:               "Working",
@@ -74,7 +74,7 @@ var _ = Describe("Updater", func() {
 				},
 			},
 			Status: rukpakv1alpha1.BundleDeploymentStatus{
-				InstalledBundleName: "bundle",
+				ActiveBundle: "bundle",
 				Conditions: []metav1.Condition{
 					{
 						Type:               "Working",
@@ -170,11 +170,11 @@ var _ = Describe("EnsureInstalledName", func() {
 
 	It("should update the installedBundleName if not set", func() {
 		Expect(bundledeployment.EnsureInstalledName(installedBundleName)(status)).To(BeTrue())
-		Expect(status.InstalledBundleName).To(Equal(installedBundleName))
+		Expect(status.ActiveBundle).To(Equal(installedBundleName))
 	})
 
 	It("should not update the installedBundleName if already set", func() {
-		status = &rukpakv1alpha1.BundleDeploymentStatus{InstalledBundleName: installedBundleName}
+		status = &rukpakv1alpha1.BundleDeploymentStatus{ActiveBundle: installedBundleName}
 		Expect(bundledeployment.EnsureInstalledName(installedBundleName)(status)).To(BeFalse())
 	})
 })

--- a/manifests/apis/crds/core.rukpak.io_bundledeployments.yaml
+++ b/manifests/apis/crds/core.rukpak.io_bundledeployments.yaml
@@ -19,8 +19,8 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.installedBundleName
-      name: Installed Bundle
+    - jsonPath: .status.activeBundle
+      name: Active Bundle
       type: string
     - jsonPath: .status.conditions[?(.type=="Installed")].reason
       name: Install State
@@ -198,6 +198,8 @@ spec:
           status:
             description: BundleDeploymentStatus defines the observed state of BundleDeployment
             properties:
+              activeBundle:
+                type: string
               conditions:
                 items:
                   description: "Condition contains details for one aspect of the current
@@ -266,8 +268,6 @@ spec:
                   - type
                   type: object
                 type: array
-              installedBundleName:
-                type: string
             type: object
         required:
         - spec

--- a/test/e2e/plain_provisioner_test.go
+++ b/test/e2e/plain_provisioner_test.go
@@ -687,7 +687,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 				if err := c.Get(ctx, client.ObjectKeyFromObject(bd), bd); err != nil {
 					return nil, err
 				}
-				if bd.Status.InstalledBundleName == "" {
+				if bd.Status.ActiveBundle == "" {
 					return nil, fmt.Errorf("waiting for bundle name to be populated")
 				}
 				return meta.FindStatusCondition(bd.Status.Conditions, rukpakv1alpha1.TypeInstalled), nil
@@ -713,7 +713,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 					return nil
 				}
 				b := &rukpakv1alpha1.Bundle{}
-				if err := c.Get(ctx, types.NamespacedName{Name: bd.Status.InstalledBundleName}, b); err != nil {
+				if err := c.Get(ctx, types.NamespacedName{Name: bd.Status.ActiveBundle}, b); err != nil {
 					return nil
 				}
 				return b.GetOwnerReferences()
@@ -728,7 +728,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 					return nil, err
 				}
 				b := &rukpakv1alpha1.Bundle{}
-				if err := c.Get(ctx, types.NamespacedName{Name: bd.Status.InstalledBundleName}, b); err != nil {
+				if err := c.Get(ctx, types.NamespacedName{Name: bd.Status.ActiveBundle}, b); err != nil {
 					return nil, err
 				}
 				return b.Labels, nil
@@ -749,7 +749,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 					if err := c.Get(ctx, client.ObjectKeyFromObject(bd), bd); err != nil {
 						return err
 					}
-					if err := c.Get(ctx, types.NamespacedName{Name: bd.Status.InstalledBundleName}, originalBundle); err != nil {
+					if err := c.Get(ctx, types.NamespacedName{Name: bd.Status.ActiveBundle}, originalBundle); err != nil {
 						return err
 					}
 					bd.Spec.Template.Spec = rukpakv1alpha1.BundleSpec{
@@ -792,7 +792,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 					if err := c.Get(ctx, client.ObjectKeyFromObject(bd), bd); err != nil {
 						return nil, err
 					}
-					if bd.Status.InstalledBundleName == "" {
+					if bd.Status.ActiveBundle == "" {
 						return nil, fmt.Errorf("waiting for bundle name to be populated")
 					}
 					return meta.FindStatusCondition(bd.Status.Conditions, rukpakv1alpha1.TypeInstalled), nil
@@ -835,7 +835,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 					if err := c.Get(ctx, client.ObjectKeyFromObject(bd), bd); err != nil {
 						return err
 					}
-					if err := c.Get(ctx, types.NamespacedName{Name: bd.Status.InstalledBundleName}, originalBundle); err != nil {
+					if err := c.Get(ctx, types.NamespacedName{Name: bd.Status.ActiveBundle}, originalBundle); err != nil {
 						return err
 					}
 					if len(bd.Spec.Template.Labels) == 0 {
@@ -851,7 +851,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 						return false
 					}
 					currBundle := &rukpakv1alpha1.Bundle{}
-					if err := c.Get(ctx, types.NamespacedName{Name: bd.Status.InstalledBundleName}, currBundle); err != nil {
+					if err := c.Get(ctx, types.NamespacedName{Name: bd.Status.ActiveBundle}, currBundle); err != nil {
 						return false
 					}
 					return util.CheckDesiredBundleTemplate(currBundle, bd.Spec.Template)
@@ -863,7 +863,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 					if err := c.Get(ctx, client.ObjectKeyFromObject(bd), bd); err != nil {
 						return nil, err
 					}
-					if bd.Status.InstalledBundleName == "" {
+					if bd.Status.ActiveBundle == "" {
 						return nil, fmt.Errorf("waiting for bundle name to be populated")
 					}
 					return meta.FindStatusCondition(bd.Status.Conditions, rukpakv1alpha1.TypeInstalled), nil
@@ -929,7 +929,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 				if err := c.Get(ctx, client.ObjectKeyFromObject(bd), bd); err != nil {
 					return nil, err
 				}
-				if bd.Status.InstalledBundleName == "" {
+				if bd.Status.ActiveBundle == "" {
 					return nil, fmt.Errorf("waiting for bundle name to be populated")
 				}
 				return meta.FindStatusCondition(bd.Status.Conditions, rukpakv1alpha1.TypeInstalled), nil
@@ -989,8 +989,8 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 				if err := c.Get(ctx, client.ObjectKeyFromObject(bd), bd); err != nil {
 					return nil, err
 				}
-				if bd.Status.InstalledBundleName != "" {
-					return nil, fmt.Errorf("bd.Status.InstalledBundleName is non-empty (%q)", bd.Status.InstalledBundleName)
+				if bd.Status.ActiveBundle != "" {
+					return nil, fmt.Errorf("bi.Status.ActiveBundle is non-empty (%q)", bd.Status.ActiveBundle)
 				}
 				return meta.FindStatusCondition(bd.Status.Conditions, rukpakv1alpha1.TypeInstalled), nil
 			}).Should(And(
@@ -1112,7 +1112,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 					if err := c.Get(ctx, client.ObjectKeyFromObject(dependentBD), dependentBD); err != nil {
 						return nil, err
 					}
-					if dependentBD.Status.InstalledBundleName == "" {
+					if dependentBD.Status.ActiveBundle == "" {
 						return nil, fmt.Errorf("waiting for bundle name to be populated")
 					}
 					return meta.FindStatusCondition(dependentBD.Status.Conditions, rukpakv1alpha1.TypeInstalled), nil
@@ -1299,7 +1299,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 				if err := c.Get(ctx, client.ObjectKeyFromObject(bd), bd); err != nil {
 					return nil, err
 				}
-				if bd.Status.InstalledBundleName == "" {
+				if bd.Status.ActiveBundle == "" {
 					return nil, fmt.Errorf("waiting for a populated installed bundle name")
 				}
 				return meta.FindStatusCondition(bd.Status.Conditions, rukpakv1alpha1.TypeInstalled), nil
@@ -1324,7 +1324,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 				if err := c.Get(ctx, client.ObjectKeyFromObject(bd), bd); err != nil {
 					return err
 				}
-				originalBundleName := bd.Status.InstalledBundleName
+				originalBundleName := bd.Status.ActiveBundle
 				b := &rukpakv1alpha1.Bundle{}
 				if err := c.Get(ctx, types.NamespacedName{Name: originalBundleName}, b); err != nil {
 					return err
@@ -1339,7 +1339,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 					return false
 				}
 
-				installedBundleName := bd.Status.InstalledBundleName
+				installedBundleName := bd.Status.ActiveBundle
 				if installedBundleName == "" {
 					return false
 				}

--- a/test/e2e/registry_provisioner_test.go
+++ b/test/e2e/registry_provisioner_test.go
@@ -18,13 +18,13 @@ import (
 var _ = Describe("registry provisioner bundle", func() {
 	When("a BundleDeployment targets a registry+v1 Bundle", func() {
 		var (
-			bi  *rukpakv1alpha1.BundleDeployment
+			bd  *rukpakv1alpha1.BundleDeployment
 			ctx context.Context
 		)
 		BeforeEach(func() {
 			ctx = context.Background()
 
-			bi = &rukpakv1alpha1.BundleDeployment{
+			bd = &rukpakv1alpha1.BundleDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "prometheus",
 				},
@@ -48,24 +48,24 @@ var _ = Describe("registry provisioner bundle", func() {
 					},
 				},
 			}
-			err := c.Create(ctx, bi)
+			err := c.Create(ctx, bd)
 			Expect(err).To(BeNil())
 		})
 		AfterEach(func() {
 			By("deleting the testing BI resource")
-			Expect(c.Delete(ctx, bi)).To(BeNil())
+			Expect(c.Delete(ctx, bd)).To(BeNil())
 		})
 
 		It("should rollout the bundle contents successfully", func() {
 			By("eventually writing a successful installation state back to the bundledeployment status")
 			Eventually(func() (*metav1.Condition, error) {
-				if err := c.Get(ctx, client.ObjectKeyFromObject(bi), bi); err != nil {
+				if err := c.Get(ctx, client.ObjectKeyFromObject(bd), bd); err != nil {
 					return nil, err
 				}
-				if bi.Status.InstalledBundleName == "" {
+				if bd.Status.ActiveBundle == "" {
 					return nil, fmt.Errorf("waiting for bundle name to be populated")
 				}
-				return meta.FindStatusCondition(bi.Status.Conditions, rukpakv1alpha1.TypeInstalled), nil
+				return meta.FindStatusCondition(bd.Status.Conditions, rukpakv1alpha1.TypeInstalled), nil
 			}).Should(And(
 				Not(BeNil()),
 				WithTransform(func(c *metav1.Condition) string { return c.Type }, Equal(rukpakv1alpha1.TypeInstalled)),


### PR DESCRIPTION
This change simplifies the BI status and improves the UX in the world
of dynamic bundles, when the bundle is known when creating the BI.

Closes #403 -- see #331 for more context. 