### PR TITLE
kubernetes 1.24 service account token secret change

### DIFF
--- a/internal/provisioner/README.md
+++ b/internal/provisioner/README.md
@@ -69,12 +69,14 @@ RBAC permissions to access bundle content.
 As an example, a client outside the cluster can view the file contents from a bundle named `my-bundle` by running
 the following script:
 
+> Note: This script requires Kubernetes 1.24+ for both client and server
+
 ```bash
 BUNDLE_NAME=my-bundle
 
 kubectl create sa fetch-bundle -n default
 kubectl create clusterrolebinding fetch-bundle --clusterrole=bundle-reader --serviceaccount=default:fetch-bundle
-export TOKEN=$(kubectl get secret -n default $(kubectl get sa -n default fetch-bundle -o jsonpath='{.secrets[0].name}') -o jsonpath='{.data.token}' | base64 -d)
+export TOKEN=$(kubectl create token fetch-bundle)
 export URL=$(kubectl get bundle $BUNDLE_NAME -o jsonpath='{.status.contentURL}')
 kubectl run -qit --rm -n default --restart=Never fetch-bundle --image=curlimages/curl --overrides='{ "spec": { "serviceAccount": "fetch-bundle" }  }' --command -- curl -sSLk -H "Authorization: Bearer $TOKEN" -o - $URL | tar ztv
 kubectl delete clusterrolebinding fetch-bundle


### PR DESCRIPTION
Signed-off-by: akihikokuroda <akuroda@us.ibm.com>

Kubernetes 1.24 doesn't have `secrets` in serviceaccount.  
This change requires 

```
Client Version: version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.0", GitCommit:"4ce5a8954017644c5420bae81d72b09b735c21f0", GitTreeState:"clean", BuildDate:"2022-05-03T13:46:05Z", GoVersion:"go1.18.1", Compiler:"gc", Platform:"linux/
amd64"}
```