### PR TITLE
API changes for bundle conversion CLI

### DIFF
--- a/pkg/bundle/plain/v0/bundle.go
+++ b/pkg/bundle/plain/v0/bundle.go
@@ -3,12 +3,12 @@ package v0
 import (
 	"io/fs"
 
-	"github.com/operator-framework/rukpak/pkg/bundle"
+	"github.com/operator-framework/rukpak/pkg/manifest"
 )
 
 // Bundle holds the contents of a plain+v0 bundle.
 type Bundle struct {
-	bundle.FS
+	manifest.FS
 
 	// external settings
 	installNamespace string
@@ -19,17 +19,10 @@ type Bundle struct {
 }
 
 // New creates a new plain+v0 bundle at the root of the given filesystem.
-func New(fsys fs.FS, opts ...func(*Bundle)) Bundle {
-	b := Bundle{createdSvcAccs: make(map[string]struct{})}
-	for _, opt := range opts {
-		opt(&b)
+func New(fsys fs.FS) Bundle {
+	if manifestFS, ok := fsys.(manifest.FS); ok {
+		return Bundle{FS: manifestFS, createdSvcAccs: make(map[string]struct{})}
 	}
 
-	if bundleFS, ok := fsys.(bundle.FS); ok {
-		b.FS = bundleFS
-	} else {
-		b.FS = bundle.New(fsys, bundle.WithManifestDirs("manifests"))
-	}
-
-	return b
+	return Bundle{FS: manifest.New(fsys, manifest.WithManifestDirs("manifests"))}
 }

--- a/pkg/bundle/registry/v1/bundle.go
+++ b/pkg/bundle/registry/v1/bundle.go
@@ -8,22 +8,22 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/operator-framework/rukpak/pkg/bundle"
+	"github.com/operator-framework/rukpak/pkg/manifest"
 )
 
 // Bundle holds the contents of a registry+v1 bundle.
 type Bundle struct {
-	bundle.FS
+	manifest.FS
 }
 
 // New creates a new registry+v1 bundle at the root of the given filesystem.
 func New(fsys fs.FS) Bundle {
 	// If the source is another bundle, use the FS
-	if bundleFS, ok := fsys.(bundle.FS); ok {
-		return Bundle{bundleFS}
+	if manifestFS, ok := fsys.(manifest.FS); ok {
+		return Bundle{manifestFS}
 	}
 
-	return Bundle{bundle.New(fsys, bundle.WithManifestDirs("manifests"))}
+	return Bundle{manifest.New(fsys, manifest.WithManifestDirs("manifests"))}
 }
 
 // CSV returns the ClusterServiceVersion manifest if one exists in the bundle.

--- a/pkg/manifest/file.go
+++ b/pkg/manifest/file.go
@@ -1,4 +1,4 @@
-package bundle
+package manifest
 
 import (
 	"bytes"
@@ -12,23 +12,23 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-// ObjectFile represents a manifest flie that contains one or more Kubernetes objects.
+// File represents a manifest flie that contains one or more Kubernetes objects.
 //
 // The objects will be stored as type `T`.
 // If `T` is an interface type, the objects can be cast to their specific structure type.
-type ObjectFile[T runtime.Object] struct {
+type File[T runtime.Object] struct {
 	Objects []T
 
 	fs.File
 	data io.Reader
 }
 
-// NewObjectFile parses the kubernetes objects contained in the file according to the scheme.
+// NewFile parses the kubernetes objects contained in the file according to the scheme.
 //
 // If `strict` is enabled, object types the scheme is not aware of will throw an error.
-func NewObjectFile[T runtime.Object](f fs.File, scheme *runtime.Scheme, strict bool) (*ObjectFile[T], error) {
+func NewFile[T runtime.Object](f fs.File, scheme *runtime.Scheme, strict bool) (*File[T], error) {
 	var (
-		file           = ObjectFile[T]{File: f, data: f}
+		file           = File[T]{File: f, data: f}
 		r    io.Reader = f
 	)
 
@@ -56,7 +56,7 @@ func NewObjectFile[T runtime.Object](f fs.File, scheme *runtime.Scheme, strict b
 }
 
 // Read bytes from the file.
-func (f ObjectFile[T]) Read(p []byte) (int, error) {
+func (f File[T]) Read(p []byte) (int, error) {
 	return f.data.Read(p)
 }
 

--- a/pkg/manifest/file_test.go
+++ b/pkg/manifest/file_test.go
@@ -1,4 +1,4 @@
-package bundle_test
+package manifest_test
 
 import (
 	"io/fs"
@@ -14,11 +14,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
-	"github.com/operator-framework/rukpak/pkg/bundle"
+	"github.com/operator-framework/rukpak/pkg/manifest"
 	"github.com/operator-framework/rukpak/test/testutil"
 )
 
-var _ = Describe("ObjectFile", func() {
+var _ = Describe("File", func() {
 	var (
 		scheme *runtime.Scheme
 		fsys   fs.FS
@@ -47,11 +47,11 @@ var _ = Describe("ObjectFile", func() {
 	})
 
 	When("casting to the concrete type", func() {
-		var objFile *bundle.ObjectFile[*operatorsv1alpha1.ClusterServiceVersion]
+		var objFile *manifest.File[*operatorsv1alpha1.ClusterServiceVersion]
 
 		JustBeforeEach(func() {
 			var err error
-			objFile, err = bundle.NewObjectFile[*operatorsv1alpha1.ClusterServiceVersion](file, scheme, false)
+			objFile, err = manifest.NewFile[*operatorsv1alpha1.ClusterServiceVersion](file, scheme, false)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -64,12 +64,12 @@ var _ = Describe("ObjectFile", func() {
 		var (
 			strictTypes = false
 
-			objFile *bundle.ObjectFile[client.Object]
+			objFile *manifest.File[client.Object]
 			err     error
 		)
 
 		JustBeforeEach(func() {
-			objFile, err = bundle.NewObjectFile[client.Object](file, scheme, strictTypes)
+			objFile, err = manifest.NewFile[client.Object](file, scheme, strictTypes)
 		})
 
 		When("the object is of a known type", func() {

--- a/pkg/manifest/fs_test.go
+++ b/pkg/manifest/fs_test.go
@@ -1,4 +1,4 @@
-package bundle_test
+package manifest_test
 
 import (
 	"io/fs"
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/operator-framework/rukpak/pkg/bundle"
+	"github.com/operator-framework/rukpak/pkg/manifest"
 	"github.com/operator-framework/rukpak/test/testutil"
 )
 
@@ -17,7 +17,7 @@ const csvFname = "manifests/memcached-operator.clusterserviceversion.yaml"
 var _ = Describe("FS", func() {
 	var (
 		baseFS fs.FS
-		fsys   bundle.FS
+		fsys   manifest.FS
 	)
 
 	BeforeEach(func() {
@@ -25,7 +25,7 @@ var _ = Describe("FS", func() {
 	})
 
 	JustBeforeEach(func() {
-		fsys = bundle.New(baseFS, bundle.WithManifestDirs("manifests"))
+		fsys = manifest.New(baseFS, manifest.WithManifestDirs("manifests"))
 	})
 
 	Describe("opening a file", func() {
@@ -52,7 +52,7 @@ var _ = Describe("FS", func() {
 
 			It("should return a normal file", func() {
 				Expect(f).ToNot(BeNil())
-				Expect(f).ToNot(BeAssignableToTypeOf(bundle.ObjectFile[client.Object]{}))
+				Expect(f).ToNot(BeAssignableToTypeOf(manifest.File[client.Object]{}))
 			})
 		})
 
@@ -67,10 +67,10 @@ var _ = Describe("FS", func() {
 
 			It("should return a manifest file", func() {
 				Expect(f).ToNot(BeNil())
-				Expect(f).To(BeAssignableToTypeOf(&bundle.ObjectFile[client.Object]{}))
+				Expect(f).To(BeAssignableToTypeOf(&manifest.File[client.Object]{}))
 
 				By("asserting the file to a manifest file type")
-				objFile := f.(*bundle.ObjectFile[client.Object])
+				objFile := f.(*manifest.File[client.Object])
 				Expect(objFile.Objects).To(HaveLen(1), "it should contain a parsed object")
 			})
 		})

--- a/pkg/manifest/manifest_suite_test.go
+++ b/pkg/manifest/manifest_suite_test.go
@@ -1,4 +1,4 @@
-package bundle_test
+package manifest_test
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestBundle(t *testing.T) {
+func TestManifest(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Bundle Suite")
+	RunSpecs(t, "Manifest Suite")
 }


### PR DESCRIPTION
This PR responds to the comments left by @joelanford  on https://github.com/operator-framework/rukpak/pull/396.

The big unknown is where to put the manifest directory restriction. For example, in a `registry+v1` bundle, manifests must be in a flat top level directory called "manifests." Since `plain+v0` bundles have a similar restriction, should the `manifest.FS` enforce that (in a configurable way) or should it be up to the bundle implementations entirely. I'm leaning towards moving it entirely to bundle implementations. Even though it introduces some mild duplication (nothing a common lib can't solve), it seems more correct to have the bundles totally own their specs. I just want confirmation before doing the work.

The other issue is that converting to a new `fstest.MapFS` is problematic since `fs.WalkDir` does not pickup any new files. I've tried adding a dummy directory, but that did not solve it. I see a few options here:

1. Find an off the shelf`fstest.MapFS` that works the way needed.
2. Try to code around it using `ReadDir` and the like, but that gets dicey if we remove the "single flat directory" restriction from the `manifest.FS` type.
3. Completely replace `fs.FS` with a more feature-filled off the shelf one like `afero`. Not a fan of this option, but putting it here for purposes of exhausting all our options.