### PR TITLE
source: remove TODO comment regarding retrying updates

### DIFF
--- a/internal/source/local.go
+++ b/internal/source/local.go
@@ -64,7 +64,6 @@ func (o *Local) Unpack(ctx context.Context, bundle *rukpakv1alpha1.Bundle) (*Res
 	labels[util.CoreOwnerKindKey] = rukpakv1alpha1.BundleKind
 	labels[util.CoreOwnerNameKey] = bundle.GetName()
 
-	// TODO: wrap this update call in a retry that ignores conflict errors
 	if err := o.Update(ctx, &cm); err != nil {
 		return nil, fmt.Errorf("could not update configmap with bundle ownerreference: %s", err)
 	}


### PR DESCRIPTION
Wrapping this call in a retry is not the best way to handle a conflict
error. It can be instead propagated back up and retried.