### PR TITLE
docs: add hackmd links

### DIFF
--- a/docs/hackmd-notes.md
+++ b/docs/hackmd-notes.md
@@ -1,0 +1,18 @@
+# HackMD Notes
+
+This file contains links to a series of designs that were written during the course of RukPak development. Most design
+documents are written using HackMD, and then shared here. These design docs provide further context on the features and
+behavior of RukPak.
+
+The docs themselves may be out slightly out of date, but are still useful in understanding the project. For example, the
+BundleDeployment Kind was previously named BundleInstance.
+
+## Links
+
+* [Support Custom Bundle Content Probes](https://hackmd.io/lUnrQHaKTsCLZ6j3Q52hSQ)
+* [Supporting Local Bundle Content](https://hackmd.io/pChFoobdQNOW911zRK6L6Q)
+* [Plain Bundle Metadata Proposal](https://hackmd.io/Tk6uXGZ2SKqreteOUAF-NA)
+* [RukPak client: rukpakctl](https://hackmd.io/AJ8ygfzbTrmXv_CIiUCPtQ)
+* [Sourcing Bundle Content From Git Repositories](https://hackmd.io/TUJIB1tXRSqZzqc_tk76lg)
+* [Embedded Bundle Support](https://hackmd.io/HNWfNUbqTUGAW5VRMcc40w)
+* [Introducing The Pivoter](https://hackmd.io/aEgk-7wfTBKhjHzYryRBGQ)


### PR DESCRIPTION
Adds a section to the docs with links to all the hackmd documents on the RukPak team. Since there is no way to link to the team repository via HackMD, links to individual files are provided instead. 

This document should be kept up to date -- as new designs are written in HackMD, this document should be updated to add a link to the new design. 

Closes #441 