### PR TITLE
rukpakctl: remove use of globals and exported types; use contexts consistently

### DIFF
--- a/cmd/rukpakctl/cmd/create.go
+++ b/cmd/rukpakctl/cmd/create.go
@@ -19,15 +19,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// createCmd represents the create command
-var createCmd = &cobra.Command{
-	Use:   "create",
-	Short: "create command creates rukpak resource",
-	Long:  `create command creates specified rukpak resource.`,
-	Run: func(cmd *cobra.Command, args []string) {
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(createCmd)
+// newCreateCmd creates the "create" subcommand
+func newCreateCmd() *cobra.Command {
+	createCmd := &cobra.Command{Use: "create",
+		Short: "create command creates rukpak resource",
+		Long:  `create command creates specified rukpak resource.`,
+	}
+	createCmd.AddCommand(
+		newBundleCmd(),
+		newBundleDeploymentCmd(),
+	)
+	return createCmd
 }

--- a/cmd/rukpakctl/cmd/root.go
+++ b/cmd/rukpakctl/cmd/root.go
@@ -5,55 +5,32 @@ Copyright © 2022 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
-	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/util/homedir"
-
-	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 )
 
-var scheme *runtime.Scheme
-
-// rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "rukpakctl",
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	rootCmd := &cobra.Command{
+		Use:   "rukpakctl",
+		Short: "A brief description of your application",
+		Long: `A longer description that spans multiple lines and likely contains
 examples and usage of using your application. For example:
 
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// Run: func(cmd *cobra.Command, args []string) { },
-}
+	}
 
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
+	rootCmd.AddCommand(
+		newContentCmd(),
+		newCreateCmd(),
+	)
+
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)
-	}
-}
-
-func init() {
-	if home := homedir.HomeDir(); home != "" {
-		rootCmd.PersistentFlags().String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
-	} else {
-		rootCmd.PersistentFlags().String("kubeconfig", "", "absolute path to the kubeconfig file")
-	}
-	rootCmd.PersistentFlags().String("namespace", "rukpak-system", "namespace for target or work resources")
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	scheme = runtime.NewScheme()
-	err := rukpakv1alpha1.AddToScheme(scheme)
-	if err != nil {
-		fmt.Printf("failed to add schema: %+v\n", err)
-		return
 	}
 }

--- a/cmd/rukpakctl/main.go
+++ b/cmd/rukpakctl/main.go
@@ -4,7 +4,9 @@ Copyright © 2022 NAME HERE <EMAIL ADDRESS>
 */
 package main
 
-import "github.com/operator-framework/rukpak/cmd/rukpakctl/cmd"
+import (
+	"github.com/operator-framework/rukpak/cmd/rukpakctl/cmd"
+)
 
 func main() {
 	cmd.Execute()

--- a/cmd/rukpakctl/utils/utils.go
+++ b/cmd/rukpakctl/utils/utils.go
@@ -15,7 +15,7 @@ import (
 	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-func CreateConfigmap(core typedv1.CoreV1Interface, name, dir, namespace string) (string, error) {
+func CreateConfigmap(ctx context.Context, core typedv1.CoreV1Interface, name, dir, namespace string) (string, error) {
 	// Create a bundle configmap
 	data := map[string]string{}
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
@@ -42,6 +42,6 @@ func CreateConfigmap(core typedv1.CoreV1Interface, name, dir, namespace string) 
 		},
 		Data: data,
 	}
-	configmap, err = core.ConfigMaps(namespace).Create(context.Background(), configmap, metav1.CreateOptions{})
+	configmap, err = core.ConfigMaps(namespace).Create(ctx, configmap, metav1.CreateOptions{})
 	return configmap.ObjectMeta.Name, err
 }

--- a/internal/provisioner/plain/controllers/bundle_controller.go
+++ b/internal/provisioner/plain/controllers/bundle_controller.go
@@ -271,6 +271,6 @@ func (r *BundleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// The default unpacker creates Pod's ownerref'd to its bundle, so
 		// we need to watch pods to ensure we reconcile events coming from these
 		// pods.
-		Watches(&crsource.Kind{Type: &corev1.Pod{}}, util.MapOwneeToOwnerProvisionerHandler(context.TODO(), mgr.GetClient(), l, plain.ProvisionerID, &rukpakv1alpha1.Bundle{})).
+		Watches(&crsource.Kind{Type: &corev1.Pod{}}, util.MapOwneeToOwnerProvisionerHandler(context.Background(), mgr.GetClient(), l, plain.ProvisionerID, &rukpakv1alpha1.Bundle{})).
 		Complete(r)
 }

--- a/internal/provisioner/plain/controllers/bundledeployment_controller.go
+++ b/internal/provisioner/plain/controllers/bundledeployment_controller.go
@@ -484,7 +484,7 @@ func isResourceNotFoundErr(err error) bool {
 func (r *BundleDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	controller, err := ctrl.NewControllerManagedBy(mgr).
 		For(&rukpakv1alpha1.BundleDeployment{}, builder.WithPredicates(util.BundleDeploymentProvisionerFilter(plain.ProvisionerID))).
-		Watches(&source.Kind{Type: &rukpakv1alpha1.Bundle{}}, handler.EnqueueRequestsFromMapFunc(util.MapBundleToBundleDeploymentHandler(mgr.GetClient(), mgr.GetLogger()))).
+		Watches(&source.Kind{Type: &rukpakv1alpha1.Bundle{}}, handler.EnqueueRequestsFromMapFunc(util.MapBundleToBundleDeploymentHandler(context.Background(), mgr.GetClient(), mgr.GetLogger()))).
 		Build(r)
 	if err != nil {
 		return err

--- a/internal/provisioner/registry/controllers/bundle_controller.go
+++ b/internal/provisioner/registry/controllers/bundle_controller.go
@@ -277,6 +277,6 @@ func (r *BundleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// The default unpacker creates Pod's ownerref'd to its bundle, so
 		// we need to watch pods to ensure we reconcile events coming from these
 		// pods.
-		Watches(&crsource.Kind{Type: &corev1.Pod{}}, util.MapOwneeToOwnerProvisionerHandler(context.TODO(), mgr.GetClient(), l, registry.ProvisionerID, &rukpakv1alpha1.Bundle{})).
+		Watches(&crsource.Kind{Type: &corev1.Pod{}}, util.MapOwneeToOwnerProvisionerHandler(context.Background(), mgr.GetClient(), l, registry.ProvisionerID, &rukpakv1alpha1.Bundle{})).
 		Complete(r)
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -113,7 +113,7 @@ func MapBundleDeploymentToBundles(ctx context.Context, c client.Client, bd rukpa
 
 func MapBundleToBundleDeployments(ctx context.Context, c client.Client, b rukpakv1alpha1.Bundle) []*rukpakv1alpha1.BundleDeployment {
 	bundleDeployments := &rukpakv1alpha1.BundleDeploymentList{}
-	if err := c.List(context.Background(), bundleDeployments); err != nil {
+	if err := c.List(ctx, bundleDeployments); err != nil {
 		return nil
 	}
 	var bds []*rukpakv1alpha1.BundleDeployment
@@ -130,12 +130,12 @@ func MapBundleToBundleDeployments(ctx context.Context, c client.Client, b rukpak
 	return bds
 }
 
-func MapBundleToBundleDeploymentHandler(cl client.Client, log logr.Logger) handler.MapFunc {
+func MapBundleToBundleDeploymentHandler(ctx context.Context, cl client.Client, log logr.Logger) handler.MapFunc {
 	return func(object client.Object) []reconcile.Request {
 		b := object.(*rukpakv1alpha1.Bundle)
 
 		var requests []reconcile.Request
-		matchingBDs := MapBundleToBundleDeployments(context.Background(), cl, *b)
+		matchingBDs := MapBundleToBundleDeployments(ctx, cl, *b)
 		for _, bd := range matchingBDs {
 			requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(bd)})
 		}


### PR DESCRIPTION
This is step 1 of making some improvements discussed in #464, which is a minor refactoring of the rukpakctl commands to remove global vars and unnecessarily exported types.

I also uncovered a few places we should be passing contexts down, so I've made those fixes as well.

Step 2 will follow up with further changes, to include:
- renaming `local` to `configmaps`
- supporting multiple configmap references which include their directory paths within bundle
- forcing the configmap references to be in the rukpak-system namespace (that way bundle controllers don't have to cache all configmaps on the cluster)


Signed-off-by: Joe Lanford <joe.lanford@gmail.com>