### PR TITLE
ci: Add version pin for the markdown linter action

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Lint markdown files
-        uses: github/super-linter/slim@v4
+        uses: github/super-linter/slim@v4.9.4
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Lint markdown files
-        uses: github/super-linter/slim@v4.9.4
+        uses: github/super-linter/slim@v4.9.5
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main

--- a/docs/plain-bundle-spec.md
+++ b/docs/plain-bundle-spec.md
@@ -21,6 +21,8 @@ is able to source `plain+v0` bundles and install them onto a Kubernetes cluster.
 > Note: the plain+v0 bundle format is at schema version v0, which means it's an experimental format that is subject
 > to change.
 
+Random change.
+
 Supported source types for a plain bundle currently include the following:
 
 * A container image


### PR DESCRIPTION
We're seeing random markdown linting failures recently. Might be due to a new version of the super-linter action.

Signed-off-by: timflannagan <timflannagan@gmail.com>