### PR TITLE
provisioner class name validation

### DIFF
--- a/api/v1alpha1/bundle_types.go
+++ b/api/v1alpha1/bundle_types.go
@@ -50,6 +50,7 @@ const (
 
 // BundleSpec defines the desired state of Bundle
 type BundleSpec struct {
+	//+kubebuilder:validation:Pattern:=^[a-z][a-z\.\/]*[a-z]$
 	// ProvisionerClassName sets the name of the provisioner that should reconcile this BundleDeployment.
 	ProvisionerClassName string `json:"provisionerClassName"`
 	// Source defines the configuration for the underlying Bundle content.

--- a/api/v1alpha1/bundledeployment_types.go
+++ b/api/v1alpha1/bundledeployment_types.go
@@ -45,6 +45,7 @@ const (
 
 // BundleDeploymentSpec defines the desired state of BundleDeployment
 type BundleDeploymentSpec struct {
+	//+kubebuilder:validation:Pattern:=^[a-z][a-z\.\/]*[a-z]$
 	// ProvisionerClassName sets the name of the provisioner that should reconcile this BundleDeployment.
 	ProvisionerClassName string `json:"provisionerClassName"`
 	// Template describes the generated Bundle that this deployment will manage.

--- a/manifests/apis/crds/core.rukpak.io_bundledeployments.yaml
+++ b/manifests/apis/crds/core.rukpak.io_bundledeployments.yaml
@@ -51,6 +51,7 @@ spec:
               provisionerClassName:
                 description: ProvisionerClassName sets the name of the provisioner
                   that should reconcile this BundleDeployment.
+                pattern: ^[a-z][a-z\.\/]*[a-z]$
                 type: string
               template:
                 description: Template describes the generated Bundle that this deployment
@@ -83,6 +84,7 @@ spec:
                       provisionerClassName:
                         description: ProvisionerClassName sets the name of the provisioner
                           that should reconcile this BundleDeployment.
+                        pattern: ^[a-z][a-z\.\/]*[a-z]$
                         type: string
                       source:
                         description: Source defines the configuration for the underlying

--- a/manifests/apis/crds/core.rukpak.io_bundles.yaml
+++ b/manifests/apis/crds/core.rukpak.io_bundles.yaml
@@ -52,6 +52,7 @@ spec:
               provisionerClassName:
                 description: ProvisionerClassName sets the name of the provisioner
                   that should reconcile this BundleDeployment.
+                pattern: ^[a-z][a-z\.\/]*[a-z]$
                 type: string
               source:
                 description: Source defines the configuration for the underlying Bundle

--- a/test/e2e/plain_provisioner_test.go
+++ b/test/e2e/plain_provisioner_test.go
@@ -61,7 +61,7 @@ var _ = Describe("plain provisioner bundle", func() {
 			By("creating the testing Bundle resource")
 			bundle = &rukpakv1alpha1.Bundle{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "olm-crds-valid",
+					Name: "olm-crds-valid",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
 					ProvisionerClassName: "non-existent-class-name",
@@ -74,20 +74,11 @@ var _ = Describe("plain provisioner bundle", func() {
 				},
 			}
 			err := c.Create(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).To(WithTransform(func(e error) string { return e.Error() }, (ContainSubstring(`"olm-crds-valid" is invalid: spec.provisionerClassName`))))
 		})
-		AfterEach(func() {
-			By("deleting the testing Bundle resource")
+		It("the testing Bundle resource is not created", func() {
 			err := c.Delete(ctx, bundle)
-			Expect(err).To(BeNil())
-		})
-		It("should consistently contain an empty status", func() {
-			Consistently(func() bool {
-				if err := c.Get(ctx, client.ObjectKeyFromObject(bundle), bundle); err != nil {
-					return false
-				}
-				return len(bundle.Status.Conditions) == 0
-			}, 10*time.Second, 1*time.Second).Should(BeTrue())
+			Expect(err).To(WithTransform(apierrors.IsNotFound, BeTrue()))
 		})
 	})
 	When("a valid Bundle referencing a remote container image is created", func() {


### PR DESCRIPTION
This PR add validation for the provisoner class name. 

- contain only lowercase alphanumeric characters, '/' or '.'
- start with an alphabetic character
- end with an alphanumeric character


Signed-off-by: akihikokuroda <akuroda@us.ibm.com>