### PR TITLE
bundledeployment name length 45

### DIFF
--- a/internal/source/image.go
+++ b/internal/source/image.go
@@ -63,7 +63,7 @@ func (i *Image) Unpack(ctx context.Context, bundle *rukpakv1alpha1.Bundle) (*Res
 func (i *Image) ensureUnpackPod(ctx context.Context, bundle *rukpakv1alpha1.Bundle, pod *corev1.Pod) (controllerutil.OperationResult, error) {
 	controllerRef := metav1.NewControllerRef(bundle, bundle.GroupVersionKind())
 	automountServiceAccountToken := false
-	pod.SetName(util.PodName(bundle.Name))
+	pod.SetName(bundle.Name)
 	pod.SetNamespace(i.PodNamespace)
 
 	return util.CreateOrRecreate(ctx, i.Client, pod, func() error {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -258,7 +258,7 @@ func CheckDesiredBundleTemplate(existingBundle *rukpakv1alpha1.Bundle, desiredBu
 func GenerateTemplateHash(template *rukpakv1alpha1.BundleTemplate) string {
 	hasher := fnv.New32a()
 	DeepHashObject(hasher, template)
-	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))
+	return rand.SafeEncodeString(fmt.Sprintf("%x", hasher.Sum32())[:6])
 }
 
 func GenerateBundleName(bdName, hash string) string {
@@ -283,10 +283,6 @@ func PodNamespace(defaultNamespace string) string {
 		return defaultNamespace
 	}
 	return string(namespace)
-}
-
-func PodName(bundleName string) string {
-	return fmt.Sprintf("unpack-bundle-%s", bundleName)
 }
 
 func BundleLabels(bundleName string) map[string]string {

--- a/manifests/apis/crds/kustomization.yml
+++ b/manifests/apis/crds/kustomization.yml
@@ -8,3 +8,9 @@ patches:
     version: v1
     kind: CustomResourceDefinition
     name: bundles.core.rukpak.io
+- path: patches/bundledeployment_validation.yaml
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: bundledeployments.core.rukpak.io

--- a/manifests/apis/crds/patches/bundle_validation.yaml
+++ b/manifests/apis/crds/patches/bundle_validation.yaml
@@ -1,11 +1,11 @@
-# limit bundle name length up to 40
+# the max bundle name up to 52
+# it allows extra 11 letters for related resource names
 - op: add
   path: /spec/versions/0/schema/openAPIV3Schema/properties/metadata/properties
   value:
     name:
       type: string
-      maxLength: 40
-
+      maxLength: 52
 # Union source type
 - op: add
   path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/source/oneOf

--- a/manifests/apis/crds/patches/bundledeployment_validation.yaml
+++ b/manifests/apis/crds/patches/bundledeployment_validation.yaml
@@ -1,0 +1,10 @@
+# limit bundledeployment name length up to 45
+# this limits the max bundle name up to 52 (allows 11 extra letters)
+# the length of the bundle name is the length of bundledeployment name plus 7  
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/metadata/properties
+  value:
+    name:
+      type: string
+      maxLength: 45
+

--- a/test/e2e/api_validation_test.go
+++ b/test/e2e/api_validation_test.go
@@ -23,12 +23,11 @@ var _ = Describe("bundle api validation", func() {
 			err    error
 		)
 		BeforeEach(func() {
-			By("creating the Bundle resource with a long name")
 			ctx = context.Background()
 
 			bundle = &rukpakv1alpha1.Bundle{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "bundlename-0123456789012345678901234567891",
+					Name: "olm-crds-too-long-name-for-the-bundle-1234567890-1234567890",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
 					ProvisionerClassName: plain.ProvisionerID,
@@ -48,10 +47,9 @@ var _ = Describe("bundle api validation", func() {
 			Expect(err).To(WithTransform(apierrors.IsNotFound, BeTrue()))
 		})
 		It("should fail the long name bundle creation", func() {
-			Expect(err).To(MatchError(ContainSubstring("metadata.name: Too long: may not be longer than 40")))
+			Expect(err).To(MatchError(ContainSubstring("metadata.name: Too long: may not be longer than 52")))
 		})
 	})
-
 	When("the bundle with multiple sources", func() {
 		var (
 			bundle *rukpakv1alpha1.Bundle
@@ -244,6 +242,45 @@ var _ = Describe("bundle api validation", func() {
 })
 
 var _ = Describe("bundle deployment api validation", func() {
+	When("the bundledeployment name is too long", func() {
+		var (
+			bd  *rukpakv1alpha1.BundleDeployment
+			ctx context.Context
+			err error
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+
+			bd = &rukpakv1alpha1.BundleDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "olm-crds-too-long-name-for-the-bundledeployment-1234567890",
+				},
+				Spec: rukpakv1alpha1.BundleDeploymentSpec{
+					ProvisionerClassName: plain.ProvisionerID,
+					Template: &rukpakv1alpha1.BundleTemplate{
+						Spec: rukpakv1alpha1.BundleSpec{
+							ProvisionerClassName: plain.ProvisionerID,
+							Source: rukpakv1alpha1.BundleSource{
+								Type: rukpakv1alpha1.SourceTypeImage,
+								Image: &rukpakv1alpha1.ImageSource{
+									Ref: "testdata/bundles/plain-v0:valid",
+								},
+							},
+						},
+					},
+				},
+			}
+			err = c.Create(ctx, bd)
+		})
+		AfterEach(func() {
+			By("deleting the testing BundleDeployment resource for failure case")
+			err = c.Delete(ctx, bd)
+			Expect(err).To(WithTransform(apierrors.IsNotFound, BeTrue()))
+		})
+		It("should fail the long name bundledeployment creation", func() {
+			Expect(err).To(MatchError(ContainSubstring("metadata.name: Too long: may not be longer than 45")))
+		})
+	})
 	When("a BundleDeployment references an invalid provisioner class name", func() {
 		var (
 			bd  *rukpakv1alpha1.BundleDeployment

--- a/test/e2e/plain_provisioner_test.go
+++ b/test/e2e/plain_provisioner_test.go
@@ -306,7 +306,7 @@ var _ = Describe("plain provisioner bundle", func() {
 			Eventually(func() bool {
 				pod := &corev1.Pod{}
 				if err := c.Get(ctx, types.NamespacedName{
-					Name:      util.PodName(bundle.GetName()),
+					Name:      bundle.GetName(),
 					Namespace: defaultSystemNamespace,
 				}, pod); err != nil {
 					return false


### PR DESCRIPTION
This PR 

- limit the length of bundledeployment to 45
- limit the length of bundle to 52
- make the name to unpack pod same as the bundle name
- shorten the bundle name length to the bundledeployment name length + 7 letters


Closes #485 