### PR TITLE
Provisioner class names must be DNS 1123 labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ spec:
     type: image
     image:
       ref: my-bundle@sha256:xyz123
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain
 ```
 
 > Note: Bundles are considered immutable once they are created. See the [bundle immutability doc](/docs/bundle-immutability.md)
@@ -161,7 +161,7 @@ kind: BundleDeployment
 metadata:
   name: my-bundle-deployment
 spec:
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain
   template:
     metadata:
       labels:
@@ -171,7 +171,7 @@ spec:
         type: image
         image:
           ref: my-bundle@sha256:xyz123
-      provisionerClassName: core.rukpak.io/plain
+      provisionerClassName: core-rukpak-io-plain
 ```
 
 ### Provisioner

--- a/api/v1alpha1/bundle_types.go
+++ b/api/v1alpha1/bundle_types.go
@@ -51,7 +51,7 @@ const (
 
 // BundleSpec defines the desired state of Bundle
 type BundleSpec struct {
-	//+kubebuilder:validation:Pattern:=^[a-z][a-z\.\/]*[a-z]$
+	//+kubebuilder:validation:Pattern:=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// ProvisionerClassName sets the name of the provisioner that should reconcile this BundleDeployment.
 	ProvisionerClassName string `json:"provisionerClassName"`
 	// Source defines the configuration for the underlying Bundle content.

--- a/api/v1alpha1/bundledeployment_types.go
+++ b/api/v1alpha1/bundledeployment_types.go
@@ -46,7 +46,7 @@ const (
 
 // BundleDeploymentSpec defines the desired state of BundleDeployment
 type BundleDeploymentSpec struct {
-	//+kubebuilder:validation:Pattern:=^[a-z][a-z\.\/]*[a-z]$
+	//+kubebuilder:validation:Pattern:=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
 	// ProvisionerClassName sets the name of the provisioner that should reconcile this BundleDeployment.
 	ProvisionerClassName string `json:"provisionerClassName"`
 	// Template describes the generated Bundle that this deployment will manage.

--- a/cmd/rukpakctl/cmd/bundle.go
+++ b/cmd/rukpakctl/cmd/bundle.go
@@ -30,6 +30,7 @@ import (
 
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	"github.com/operator-framework/rukpak/cmd/rukpakctl/utils"
+	plain "github.com/operator-framework/rukpak/internal/provisioner/plain/types"
 )
 
 type bundleOptions struct {
@@ -104,7 +105,7 @@ func bundle(ctx context.Context, opt bundleOptions, args []string) error {
 			GenerateName: namePrefix,
 		},
 		Spec: rukpakv1alpha1.BundleSpec{
-			ProvisionerClassName: "core.rukpak.io/plain",
+			ProvisionerClassName: plain.ProvisionerID,
 			Source: rukpakv1alpha1.BundleSource{
 				Type: rukpakv1alpha1.SourceTypeLocal,
 				Local: &rukpakv1alpha1.LocalSource{

--- a/cmd/rukpakctl/cmd/bundledeployment.go
+++ b/cmd/rukpakctl/cmd/bundledeployment.go
@@ -30,6 +30,7 @@ import (
 
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	"github.com/operator-framework/rukpak/cmd/rukpakctl/utils"
+	plain "github.com/operator-framework/rukpak/internal/provisioner/plain/types"
 )
 
 type bundleDeploymentOptions struct {
@@ -103,10 +104,10 @@ func bundleDeployment(ctx context.Context, opt bundleDeploymentOptions, args []s
 			GenerateName: namePrefix,
 		},
 		Spec: rukpakv1alpha1.BundleDeploymentSpec{
-			ProvisionerClassName: "core.rukpak.io/plain",
+			ProvisionerClassName: plain.ProvisionerID,
 			Template: &rukpakv1alpha1.BundleTemplate{
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: "core.rukpak.io/plain",
+					ProvisionerClassName: plain.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeLocal,
 						Local: &rukpakv1alpha1.LocalSource{

--- a/cmd/rukpakctl/cmd/run.go
+++ b/cmd/rukpakctl/cmd/run.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	plain "github.com/operator-framework/rukpak/internal/provisioner/plain/types"
 	"github.com/operator-framework/rukpak/internal/rukpakctl"
 	"github.com/operator-framework/rukpak/internal/util"
 )
@@ -136,8 +137,8 @@ one version to the next.
 	cmd.Flags().StringVar(&systemNamespace, "system-namespace", "rukpak-system", "the namespace in which the rukpak controllers are deployed.")
 	cmd.Flags().StringVar(&uploadServiceName, "upload-service-name", "core", "the name of the service of the upload manager.")
 	cmd.Flags().StringVar(&caSecretName, "ca-secret-name", "rukpak-ca", "the name of the secret in the system namespace containing the root CAs used to authenticate the upload service.")
-	cmd.Flags().StringVar(&bundleDeploymentProvisionerClassName, "bundle-deployment-provisioner-class", "core.rukpak.io/plain", "Provisioner class name to set on bundle deployment.")
-	cmd.Flags().StringVar(&bundleProvisionerClassName, "bundle-provisioner-class", "core.rukpak.io/plain", "Provisioner class name to set on bundle.")
+	cmd.Flags().StringVar(&bundleDeploymentProvisionerClassName, "bundle-deployment-provisioner-class", plain.ProvisionerID, "Provisioner class name to set on bundle deployment.")
+	cmd.Flags().StringVar(&bundleProvisionerClassName, "bundle-provisioner-class", plain.ProvisionerID, "Provisioner class name to set on bundle.")
 	return cmd
 }
 

--- a/docs/bundle-immutability.md
+++ b/docs/bundle-immutability.md
@@ -31,7 +31,7 @@ spec:
       ref:
         tag: v0.0.2
       repository: https://github.com/operator-framework/combo
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain
 EOF
 ```
 

--- a/docs/git-bundles.md
+++ b/docs/git-bundles.md
@@ -63,7 +63,7 @@ spec:
         secret:
           name: gitsecret
           insecureSkipVerify: false
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain
 EOF
 ```
 
@@ -97,7 +97,7 @@ spec:
         secret:
           name: gitsecret
           insecureSkipVerify: false
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain
 EOF
 ```
 
@@ -118,7 +118,7 @@ spec:
       ref:
         commit: d40082c96e6f0d297aa316d84020d307f95dc453
       repository: https://github.com/operator-framework/combo
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain
 ```
 
 plain+v0 Bundle that references a git repository by a tag:
@@ -135,7 +135,7 @@ spec:
       ref:
         tag: v0.0.2
       repository: https://github.com/operator-framework/combo
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain
 ```
 
 plain+v0 Bundle that references a git repository by a branch:
@@ -152,7 +152,7 @@ spec:
       ref:
         branch: main
       repository: https://github.com/operator-framework/combo
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain
 ```
 
 plain+v0 Bundle that has a different manifest directory than the default:
@@ -170,6 +170,6 @@ spec:
         branch: main
       directory: ./dev/deploy
       repository: https://github.com/exdx/combo-bundle
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain
 ```
 

--- a/docs/local-bundles.md
+++ b/docs/local-bundles.md
@@ -46,6 +46,6 @@ spec:
       configmap:
         name: my-configmay
         namespace: rukpak-system
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain
 EOF
 ```

--- a/docs/plain-bundle-spec.md
+++ b/docs/plain-bundle-spec.md
@@ -156,7 +156,7 @@ kind: BundleDeployment
 metadata:
   name: my-bundle
 spec:
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain
   template:
     metadata:
       labels:
@@ -166,7 +166,7 @@ spec:
         type: image
         image:
           ref: quay.io/operator-framework/rukpak:example
-      provisionerClassName: core.rukpak.io/plain
+      provisionerClassName: core-rukpak-io-plain
 EOF
 ```
 
@@ -211,7 +211,7 @@ spec:
     image:
       ref: quay.io/my-registry/rukpak:example
       pullSecret: mysecret
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain
 EOF
 ```
 

--- a/docs/provisioner-spec.md
+++ b/docs/provisioner-spec.md
@@ -23,7 +23,9 @@ provisioners must include certain functionality and capabilities.
 ## Requirements
 
 1. A provisioner _must_ define one or more globally unique names for the `Bundle` and `BundleDeployment` controllers it
-runs.
+runs. For the purposes of provisioner class name references, this name must also conform to the
+[DNS label schema](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names) as defined
+in RFC 1123.
 2. A provisioner _should_ use its unique controller names when configuring its watch predicates so that it only
 reconciles bundles and bundle deployments that use its name.
 3. A provisioner is not required to implement controllers for both bundles and bundle deployments.

--- a/docs/uploading-bundles.md
+++ b/docs/uploading-bundles.md
@@ -18,7 +18,7 @@ to a local directory that contains a bundle.
 rukpakctl run <bundleDeploymentName> <bundleDir>
 ```
 
-By default, `rukpakctl run` assumes that the bundle is a plain bundle and uses `core.rukpak.io/plain` as the
+By default, `rukpakctl run` assumes that the bundle is a plain bundle and uses `core-rukpak-io-plain` as the
 provisioner class names for both the bundle template and the bundle deployment spec.
 
 The `--bundle-provisioner-class` and `--bundle-deployment-provisioner-class` flags can be used to

--- a/internal/provisioner/helm/README.md
+++ b/internal/provisioner/helm/README.md
@@ -4,7 +4,7 @@
 
 The `helm` provisioner is able to instantiate a given `helm+v3` bundle with a specified helm chart onto a cluster and then install the helm chart,
 in the cluster. It does so by reconciling `Bundle` and `BundleDeployment` types that have
-the `spec.provisionerClassName` field set to `core.rukpak.io/helm`. This field must be set to the correct provisioner
+the `spec.provisionerClassName` field set to `core-rukpak-io-helm`. This field must be set to the correct provisioner
 name in order for the `helm` provisioner to see and interact with the bundle.
 
 ### Install and apply a specific version of a `helm+v3` bundle
@@ -25,7 +25,7 @@ kind: BundleDeployment
 metadata:
   name: my-ahoy
 spec:
-  provisionerClassName: core.rukpak.io/helm
+  provisionerClassName: core-rukpak-io-helm
   config:
     values: |
       # Default values for hello-world.
@@ -55,7 +55,7 @@ spec:
       labels:
         app: my-ahoy
     spec:
-      provisionerClassName: core.rukpak.io/helm
+      provisionerClassName: core-rukpak-io-helm
       source:
         https:
           url: https://github.com/helm/examples/releases/download/hello-world-0.1.0/hello-world-0.1.0.tgz  
@@ -120,13 +120,13 @@ kind: BundleDeployment
 metadata:
   name: my-ahoy
 spec:
-  provisionerClassName: core.rukpak.io/helm
+  provisionerClassName: core-rukpak-io-helm
   template:
     metadata:
       labels:
         app: my-ahoy
     spec:
-      provisionerClassName: core.rukpak.io/helm
+      provisionerClassName: core-rukpak-io-helm
       source:
         https:
           url: https://github.com/helm/examples/releases/download/hello-world-0.1.0/hello-world-0.1.0.tgz
@@ -224,7 +224,7 @@ kind: BundleDeployment
 metadata:
   name: my-ahoy
 spec:
-  provisionerClassName: core.rukpak.io/helm
+  provisionerClassName: core-rukpak-io-helm
   config:
     values: |
       # Default values for hello-world.
@@ -254,7 +254,7 @@ spec:
       labels:
         app: my-ahoy
     spec:
-      provisionerClassName: core.rukpak.io/helm
+      provisionerClassName: core-rukpak-io-helm
       source:
         https:
           url: https://github.com/helm/examples/releases/download/hello-world-0.1.0/hello-world-0.1.0.tgz  

--- a/internal/provisioner/helm/types/types.go
+++ b/internal/provisioner/helm/types/types.go
@@ -2,5 +2,5 @@ package helm
 
 const (
 	// ProvisionerID is the unique plain provisioner ID
-	ProvisionerID = "core.rukpak.io/helm"
+	ProvisionerID = "core-rukpak-io-helm"
 )

--- a/internal/provisioner/plain/README.md
+++ b/internal/provisioner/plain/README.md
@@ -9,7 +9,7 @@ the [plain+v0 bundle spec](/docs/plain-bundle-spec.md).
 
 The `plain` provisioner is able to unpack a given `plain+v0` bundle onto a cluster and then instantiate it, making the
 content of the bundle available in the cluster. It does so by reconciling `Bundle` and `BundleDeployment` types that have
-the `spec.provisionerClassName` field set to `core.rukpak.io/plain`. This field must be set to the correct provisioner
+the `spec.provisionerClassName` field set to `core-rukpak-io-plain`. This field must be set to the correct provisioner
 name in order for the `plain` provisioner to see and interact with the bundle.
 
 ### Install and apply a specific version of a `plain+v0` bundle
@@ -30,7 +30,7 @@ kind: BundleDeployment
 metadata:
   name: my-bundle-deployment
 spec:
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain
   template:
     metadata:
       labels:
@@ -40,7 +40,7 @@ spec:
         type: image
         image:
           ref: my-bundle@sha256:xyz123
-      provisionerClassName: core.rukpak.io/plain
+      provisionerClassName: core-rukpak-io-plain
 ```
 
 > Note: the generated Bundle will contain the BundleDeployment's metadata.Name as a prefix, followed by
@@ -107,13 +107,13 @@ kind: BundleDeployment
 metadata:
   name: combo
 spec:
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain
   template:
     metadata:
       labels:
         app: combo
     spec:
-      provisionerClassName: core.rukpak.io/plain
+      provisionerClassName: core-rukpak-io-plain
       source:
         image:
           ref: quay.io/operator-framework/combo-bundle:v0.0.1
@@ -218,13 +218,13 @@ kind: BundleDeployment
 metadata:
   name: combo
 spec:
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain
   template:
     metadata:
       labels:
         app: combo
     spec:
-      provisionerClassName: core.rukpak.io/plain
+      provisionerClassName: core-rukpak-io-plain
       source:
         image:
           ref: quay.io/operator-framework/combo-bundle:v0.0.2

--- a/internal/provisioner/plain/types/types.go
+++ b/internal/provisioner/plain/types/types.go
@@ -2,5 +2,5 @@ package plain
 
 const (
 	// ProvisionerID is the unique plain provisioner ID
-	ProvisionerID = "core.rukpak.io/plain"
+	ProvisionerID = "core-rukpak-io-plain"
 )

--- a/internal/provisioner/registry/README.md
+++ b/internal/provisioner/registry/README.md
@@ -9,9 +9,9 @@ the [OLM packaging doc](https://olm.operatorframework.io/docs/tasks/creating-ope
 
 The `registry` provisioner is able to convert a given `registry+v1` bundle onto a cluster in the `plain+v0` format. Instantiation of the
 bundle is then handled by the `plain` provisioner in order to make the content available in the cluster. It does so by reconciling `Bundle`
-types that have the `spec.provisionerClassName` field set to `core.rukpak.io/registry`. This field must be set to the correct provisioner
+types that have the `spec.provisionerClassName` field set to `core-rukpak-io-registry`. This field must be set to the correct provisioner
 name in order for the `registry` provisioner to see and interact with the bundle. Creating a `BundleDeployment` of that `Bundle` would then
-require that you have set the `BundleDeployment` property `spec.provisionerClassName` field to `core.rukpak.io/plain`. For a concrete example
+require that you have set the `BundleDeployment` property `spec.provisionerClassName` field to `core-rukpak-io-plain`. For a concrete example
 of this in action, see the [use cases section](#use-cases)
 
 > Note: Not all `registry+v1` content is supported. This mainly applies to `registry+v1` bundles that enable `AllNamespaces` mode
@@ -37,7 +37,7 @@ kind: BundleDeployment
 metadata:
   name: my-bundle-deployment
 spec:
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain
   template:
     metadata:
       labels:
@@ -47,7 +47,7 @@ spec:
         type: image
         image:
           ref: my-bundle@sha256:xyz123
-      provisionerClassName: core.rukpak.io/registry
+      provisionerClassName: core-rukpak-io-registry
 ```
 
 > Note: The generated Bundle will contain the BundleDeployment's metadata.Name as a prefix, followed by
@@ -114,13 +114,13 @@ kind: BundleDeployment
 metadata:
   name: prometheus
 spec:
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain
   template:
     metadata:
       labels:
         app: prometheus
     spec:
-      provisionerClassName: core.rukpak.io/registry
+      provisionerClassName: core-rukpak-io-registry
       source:
         type: image
         image:
@@ -222,13 +222,13 @@ kind: BundleDeployment
 metadata:
   name: prometheus
 spec:
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain
   template:
     metadata:
       labels:
         app: prometheus
     spec:
-      provisionerClassName: core.rukpak.io/registry
+      provisionerClassName: core-rukpak-io-registry
       source:
         type: image
         image:

--- a/internal/provisioner/registry/types/types.go
+++ b/internal/provisioner/registry/types/types.go
@@ -2,5 +2,5 @@ package registry
 
 const (
 	// ProvisionerID is the unique registry provisioner ID
-	ProvisionerID = "core.rukpak.io/registry"
+	ProvisionerID = "core-rukpak-io-registry"
 )

--- a/manifests/apis/crds/core.rukpak.io_bundledeployments.yaml
+++ b/manifests/apis/crds/core.rukpak.io_bundledeployments.yaml
@@ -55,7 +55,7 @@ spec:
               provisionerClassName:
                 description: ProvisionerClassName sets the name of the provisioner
                   that should reconcile this BundleDeployment.
-                pattern: ^[a-z][a-z\.\/]*[a-z]$
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
               template:
                 description: Template describes the generated Bundle that this deployment
@@ -88,7 +88,7 @@ spec:
                       provisionerClassName:
                         description: ProvisionerClassName sets the name of the provisioner
                           that should reconcile this BundleDeployment.
-                        pattern: ^[a-z][a-z\.\/]*[a-z]$
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                         type: string
                       source:
                         description: Source defines the configuration for the underlying

--- a/manifests/apis/crds/core.rukpak.io_bundles.yaml
+++ b/manifests/apis/crds/core.rukpak.io_bundles.yaml
@@ -52,7 +52,7 @@ spec:
               provisionerClassName:
                 description: ProvisionerClassName sets the name of the provisioner
                   that should reconcile this BundleDeployment.
-                pattern: ^[a-z][a-z\.\/]*[a-z]$
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
               source:
                 description: Source defines the configuration for the underlying Bundle

--- a/tools/imageregistry/bundle_local_image.yaml
+++ b/tools/imageregistry/bundle_local_image.yaml
@@ -8,4 +8,4 @@ spec:
     image:
       ref: docker-registry.rukpak-e2e.svc.cluster.local:5000/bundles/plain-v0:valid
       pullSecret: registrysecret
-  provisionerClassName: core.rukpak.io/plain
+  provisionerClassName: core-rukpak-io-plain


### PR DESCRIPTION
In order to ensure that we can introduce a `ProvisionerClass` API in the
future without causing breaking changes in the `Bundle` and
`BundleDeployment` APIs, we need to ensure that `Bundle` and
`BundleDeployment` objects use provisioner class name values that can
reference the `metadata.name` field of potential `ProvisionerClass`
objects. Currently, the provisioner class names use both `.` and `/`
characters, which are invalid in certain core Kubernetes resource names.

Therefore, this commit changes the plain and registry provisioner IDs to
`core-rukpak-io-plain` and `core-rukpak-io-registry` and it changes the
validation of the `Bundle` and `BundleDeployment` provisioner class name
fields to ensure only DNS-1123 label names can be used.

This follows up on #487 and #479

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>