### PR TITLE
fix: Use top-level rukpakctl binary for e2e tests

### DIFF
--- a/test/e2e/rukpakctl_test.go
+++ b/test/e2e/rukpakctl_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	rukpakctlcmd = "../../bin/linux/rukpakctl "
+	rukpakctlcmd = "../../bin/rukpakctl "
 	testbundles  = "../../testdata/bundles/"
 )
 


### PR DESCRIPTION
Closes #489 