### PR TITLE
fix: e2e rukpakctl on mac

### DIFF
--- a/test/e2e/rukpakctl_test.go
+++ b/test/e2e/rukpakctl_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	rukpakctlcmd = "../../bin/linux/rukpakctl "
+	rukpakctlcmd = "../../bin/rukpakctl "
 	testbundles  = "../../testdata/bundles/"
 )
 


### PR DESCRIPTION
- support both linux and local binary builds in the same make invocation
- fix e2e to use local rukpakctl binary

This should resolve the issue in the e2e run that occurred in #491 

Closes #489 
Closes #491

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>