### PR TITLE
More upload source improvements

### DIFF
--- a/internal/rukpakctl/upload.go
+++ b/internal/rukpakctl/upload.go
@@ -70,7 +70,10 @@ func (bu *BundleUploader) Upload(ctx context.Context, bundleName string, bundleF
 
 	var bundleModified bool
 	eg.Go(func() error {
-		defer cancel()
+		defer func() {
+			cancel()
+			bundleWriter.Close()
+		}()
 
 		// get the local port. this will wait until the port forwarder is ready.
 		localPort, err := pf.LocalPort(ctx)


### PR DESCRIPTION
When the port forwarder fails, it results in the tar writer process
hanging indefinitely. This fixes the issue by ensuring the the writer is
closed by the time the upload process returns.

This also improves the reliability of the port forward setup by waiting
(if necessary) for a service endpoint to be available.

These are the improvements I discovered needed to be made while
working on #508