### PR TITLE
Support upload source in helm provisioner

### DIFF
--- a/internal/provisioner/helm/controllers/bundledeployment_controller.go
+++ b/internal/provisioner/helm/controllers/bundledeployment_controller.go
@@ -21,14 +21,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/fs"
-	"io/ioutil"
 	"strings"
 
 	helmclient "github.com/operator-framework/helm-operator-plugins/pkg/client"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
@@ -340,48 +337,6 @@ func (r *BundleDeploymentReconciler) loadChart(ctx context.Context, bundle *rukp
 		return nil, err
 	}
 	return getChart(chartfs)
-}
-
-func getChart(chartfs fs.FS) (*chart.Chart, error) {
-	var baseDir string
-	files := []*loader.BufferedFile{}
-	err := fs.WalkDir(chartfs, ".", func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-		if path == "." {
-			return nil
-		}
-		if baseDir == "" {
-			baseDir = path
-			return nil
-		}
-		if d.IsDir() {
-			return nil
-		}
-		f, err := chartfs.Open(path)
-		if err != nil {
-			return err
-		}
-		data, err := ioutil.ReadAll(f)
-		if err != nil {
-			return err
-		}
-		bf := loader.BufferedFile{
-			Name: path[len(baseDir)+1:],
-			Data: data,
-		}
-		files = append(files, &bf)
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	chrt, err := loader.LoadFiles(files)
-	if err != nil {
-		return nil, err
-	}
-	return chrt, nil
 }
 
 type errRequiredResourceNotFound struct {

--- a/internal/provisioner/helm/controllers/util.go
+++ b/internal/provisioner/helm/controllers/util.go
@@ -1,0 +1,34 @@
+package controllers
+
+import (
+	"io"
+	"io/fs"
+
+	"golang.org/x/sync/errgroup"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+
+	"github.com/operator-framework/rukpak/internal/util"
+)
+
+func getChart(chartfs fs.FS) (*chart.Chart, error) {
+	pr, pw := io.Pipe()
+	var eg errgroup.Group
+	eg.Go(func() error {
+		return pw.CloseWithError(util.FSToTarGZ(pw, chartfs))
+	})
+
+	var chrt *chart.Chart
+	eg.Go(func() error {
+		var err error
+		chrt, err = loader.LoadArchive(pr)
+		if err != nil {
+			return err
+		}
+		return chrt.Validate()
+	})
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	return chrt, nil
+}

--- a/internal/util/fs.go
+++ b/internal/util/fs.go
@@ -1,8 +1,12 @@
 package util
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
+	"strings"
+	"testing/fstest"
 )
 
 // FilesOnlyFilesystem is an fs.FS implementation that treats non-regular files
@@ -34,4 +38,53 @@ func (f *FilesOnlyFilesystem) Open(name string) (fs.File, error) {
 		return nil, os.ErrNotExist
 	}
 	return file, nil
+}
+
+// EnsureBaseDirFS ensures that an fs.FS contains a single directory in its root
+// This is useful for bundle formats that require a base directory in the root of
+// the bundle.
+//
+// For example, an unpacked Helm chart might have <chartDir>/Chart.yaml, and we'd
+// typically assume <chartDir> as the bundle root. However, when helm archives
+// contain <chartDir> at the root of the archive: <archiveRoot>/<chartDir>/Chart.yaml.
+//
+// If the fs.FS already has this structure, EnsureBaseDirFS just returns fsys
+// directly. Otherwise, it returns a new fs.FS where the defaultBaseDir is inserted
+// at the root, such that fsys appears within defaultBaseDir.
+func EnsureBaseDirFS(fsys fs.FS, defaultBaseDir string) (fs.FS, error) {
+	cleanDefaultBaseDir := filepath.Clean(defaultBaseDir)
+	if dir, _ := filepath.Split(cleanDefaultBaseDir); dir != "" {
+		return nil, fmt.Errorf("default base directory %q contains multiple path segments: must be exactly one", defaultBaseDir)
+	}
+	rootFSEntries, err := fs.ReadDir(fsys, ".")
+	if err != nil {
+		return nil, err
+	}
+	if len(rootFSEntries) == 1 && rootFSEntries[0].IsDir() {
+		return fsys, nil
+	}
+	return &baseDirFS{fsys, defaultBaseDir}, nil
+}
+
+type baseDirFS struct {
+	fsys    fs.FS
+	baseDir string
+}
+
+func (f baseDirFS) Open(name string) (fs.File, error) {
+	if name == "." {
+		return fstest.MapFS{f.baseDir: &fstest.MapFile{Mode: fs.ModeDir}}.Open(name)
+	}
+	if name == f.baseDir {
+		return f.fsys.Open(".")
+	}
+	basePrefix := f.baseDir + string(os.PathSeparator)
+	if strings.HasPrefix(name, basePrefix) {
+		subName := strings.TrimPrefix(name, basePrefix)
+		if subName == "" {
+			subName = "."
+		}
+		return f.fsys.Open(subName)
+	}
+	return nil, fs.ErrNotExist
 }

--- a/manifests/provisioners/helm/resources/cluster_role.yaml
+++ b/manifests/provisioners/helm/resources/cluster_role.yaml
@@ -7,6 +7,7 @@ metadata:
 rules:
 - nonResourceURLs:
   - /bundles/*
+  - /uploads/*
   verbs:
   - get
 - apiGroups:

--- a/manifests/provisioners/helm/resources/deployment.yaml
+++ b/manifests/provisioners/helm/resources/deployment.yaml
@@ -26,6 +26,7 @@ spec:
             - "--upstream=http://127.0.0.1:8080/"
             - "--logtostderr=true"
             - "--v=1"
+            - "--client-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
             - "--tls-cert-file=/etc/pki/tls/tls.crt"
             - "--tls-private-key-file=/etc/pki/tls/tls.key"
           ports:
@@ -40,6 +41,8 @@ spec:
           imagePullPolicy: IfNotPresent
           command: ["/helm"]
           args:
+            - "--unpack-image=quay.io/operator-framework/rukpak:latest"
+            - "--base-upload-manager-url=https://$(CORE_SERVICE_NAME).$(CORE_SERVICE_NAMESPACE).svc"
             - "--storage-dir=/var/cache/bundles"
             - "--http-bind-address=127.0.0.1:8080"
             - "--http-external-address=https://$(HELM_PROVISIONER_SERVICE_NAME).$(HELM_PROVISIONER_SERVICE_NAMESPACE).svc"


### PR DESCRIPTION
This PR adds support in the helm provisioner for uploaded charts. It also uses a helm library to load the chart, which ensures that the helm provisioner stays up to date with Helm's chart parsing logic.

Closes #513 
Closes #505

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>