### PR TITLE
minor touchup to core manifests

### DIFF
--- a/internal/provisioner/plain/controllers/bundle_controller.go
+++ b/internal/provisioner/plain/controllers/bundle_controller.go
@@ -58,8 +58,7 @@ type BundleReconciler struct {
 //+kubebuilder:rbac:groups=core.rukpak.io,resources=bundles,verbs=list;watch;update;patch
 //+kubebuilder:rbac:groups=core.rukpak.io,resources=bundles/status,verbs=update;patch
 //+kubebuilder:rbac:groups=core.rukpak.io,resources=bundles/finalizers,verbs=update
-//+kubebuilder:rbac:verbs=get,urls=/bundles/*
-//+kubebuilder:rbac:verbs=get,urls=/uploads/*
+//+kubebuilder:rbac:verbs=get,urls=/bundles/*;/uploads/*
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=list;watch;create;delete
 //+kubebuilder:rbac:groups=core,resources=pods/log,verbs=get
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create

--- a/internal/provisioner/registry/controllers/bundle_controller.go
+++ b/internal/provisioner/registry/controllers/bundle_controller.go
@@ -59,8 +59,7 @@ type BundleReconciler struct {
 //+kubebuilder:rbac:groups=core.rukpak.io,resources=bundles,verbs=list;watch;update;patch
 //+kubebuilder:rbac:groups=core.rukpak.io,resources=bundles/status,verbs=update;patch
 //+kubebuilder:rbac:groups=core.rukpak.io,resources=bundles/finalizers,verbs=update
-//+kubebuilder:rbac:verbs=get,urls=/bundles/*
-//+kubebuilder:rbac:verbs=get,urls=/uploads/*
+//+kubebuilder:rbac:verbs=get,urls=/bundles/*;/uploads/*
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=list;watch;create;delete
 //+kubebuilder:rbac:groups=core,resources=pods/log,verbs=get
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create

--- a/manifests/core/resources/cluster_role.yaml
+++ b/manifests/core/resources/cluster_role.yaml
@@ -7,9 +7,6 @@ metadata:
 rules:
 - nonResourceURLs:
   - /bundles/*
-  verbs:
-  - get
-- nonResourceURLs:
   - /uploads/*
   verbs:
   - get

--- a/manifests/core/resources/deployment.yaml
+++ b/manifests/core/resources/deployment.yaml
@@ -25,7 +25,7 @@ spec:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"
             - "--logtostderr=true"
-            - "--v=10"
+            - "--v=1"
             - "--client-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
             - "--tls-cert-file=/etc/pki/tls/tls.crt"
             - "--tls-private-key-file=/etc/pki/tls/tls.key"


### PR DESCRIPTION
- Minor simplification of core RBAC rules (combine upload and bundle get permission)
- Stop logging at `-v=10` verbosity in the core kube-rbac-proxy. This snuck in accidentally in an earlier PR when it was set to 10 for development debugging.

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>