### PR TITLE
De-duplicate `HasValidBundle` and `InvalidBundleContent` condition types

### DIFF
--- a/api/v1alpha1/bundledeployment_types.go
+++ b/api/v1alpha1/bundledeployment_types.go
@@ -27,21 +27,18 @@ var (
 )
 
 const (
-	TypeHasValidBundle       = "HasValidBundle"
-	TypeInvalidBundleContent = "InvalidBundleContent"
-	TypeInstalled            = "Installed"
+	TypeHasValidBundle = "HasValidBundle"
+	TypeInstalled      = "Installed"
 
-	ReasonBundleLookupFailed         = "BundleLookupFailed"
-	ReasonBundleLoadFailed           = "BundleLoadFailed"
-	ReasonReadingContentFailed       = "ReadingContentFailed"
-	ReasonErrorGettingClient         = "ErrorGettingClient"
-	ReasonErrorGettingReleaseState   = "ErrorGettingReleaseState"
-	ReasonInstallFailed              = "InstallFailed"
-	ReasonUpgradeFailed              = "UpgradeFailed"
-	ReasonReconcileFailed            = "ReconcileFailed"
-	ReasonCreateDynamicWatchFailed   = "CreateDynamicWatchFailed"
-	ReasonInstallationSucceeded      = "InstallationSucceeded"
-	ReasonMaxGeneratedBundlesReached = "MaxGenerationReached"
+	ReasonBundleLoadFailed         = "BundleLoadFailed"
+	ReasonReadingContentFailed     = "ReadingContentFailed"
+	ReasonErrorGettingClient       = "ErrorGettingClient"
+	ReasonErrorGettingReleaseState = "ErrorGettingReleaseState"
+	ReasonInstallFailed            = "InstallFailed"
+	ReasonUpgradeFailed            = "UpgradeFailed"
+	ReasonReconcileFailed          = "ReconcileFailed"
+	ReasonCreateDynamicWatchFailed = "CreateDynamicWatchFailed"
+	ReasonInstallationSucceeded    = "InstallationSucceeded"
 )
 
 // BundleDeploymentSpec defines the desired state of BundleDeployment

--- a/internal/provisioner/helm/controllers/bundledeployment_controller.go
+++ b/internal/provisioner/helm/controllers/bundledeployment_controller.go
@@ -155,8 +155,8 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	if err != nil {
 		u.UpdateStatus(
 			updater.EnsureCondition(metav1.Condition{
-				Type:    rukpakv1alpha1.TypeInvalidBundleContent,
-				Status:  metav1.ConditionTrue,
+				Type:    rukpakv1alpha1.TypeHasValidBundle,
+				Status:  metav1.ConditionFalse,
 				Reason:  rukpakv1alpha1.ReasonReadingContentFailed,
 				Message: err.Error(),
 			}))

--- a/internal/provisioner/plain/controllers/bundledeployment_controller.go
+++ b/internal/provisioner/plain/controllers/bundledeployment_controller.go
@@ -164,8 +164,8 @@ func (r *BundleDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if err != nil {
 			u.UpdateStatus(
 				updater.EnsureCondition(metav1.Condition{
-					Type:    rukpakv1alpha1.TypeInvalidBundleContent,
-					Status:  metav1.ConditionTrue,
+					Type:    rukpakv1alpha1.TypeHasValidBundle,
+					Status:  metav1.ConditionFalse,
 					Reason:  rukpakv1alpha1.ReasonReadingContentFailed,
 					Message: err.Error(),
 				}))


### PR DESCRIPTION
Closes #518 

This is related to #333 and #331, but I'm not sure it closes them. #333 seems to be about renaming the `HasValidBundle` type or at least considering how it aligns to the Bundle `Unpacked` phase/condition. #331 is more about how to represent BD state to handle pivoting situations and still have a UX that makes sense and is general enough to cover different provisioner implementations.

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>