### PR TITLE
fix: add a helm-provisioner wait to the .goreleaser.template.yml

### DIFF
--- a/.goreleaser.template.yml
+++ b/.goreleaser.template.yml
@@ -139,6 +139,7 @@ release:
     kubectl wait --for=condition=Available --namespace=cert-manager deployment/cert-manager-webhook --timeout=60s
     kubectl apply -f https://github.com/operator-framework/rukpak/releases/download/{{ .Tag }}/rukpak.yaml
     kubectl wait --for=condition=Available --namespace=rukpak-system deployment/core --timeout=60s
+    kubectl wait --for=condition=Available --namespace=rukpak-system deployment/helm-provisioner --timeout=60s
     kubectl wait --for=condition=Available --namespace=rukpak-system deployment/rukpak-webhooks --timeout=60s
     kubectl wait --for=condition=Available --namespace=crdvalidator-system deployment/crd-validation-webhook --timeout=60s
     ```


### PR DESCRIPTION
When creating the recent release it was found that we didn't add a wait to the release instructions for the `goreleaser.template.yaml`.

Closes #537 