### PR TITLE
feat: add PSA compliance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static:debug
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 
 COPY helm helm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:debug-nonroot
+
 WORKDIR /
 
 COPY helm helm

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	k8s.io/apimachinery v0.24.2
 	k8s.io/cli-runtime v0.24.2
 	k8s.io/client-go v0.24.2
+	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/controller-runtime v0.12.3
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -169,7 +170,6 @@ require (
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	k8s.io/kubectl v0.24.1 // indirect
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	oras.land/oras-go v1.1.0 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/kustomize/api v0.11.4 // indirect

--- a/manifests/apis/webhooks/resources/deployment.yaml
+++ b/manifests/apis/webhooks/resources/deployment.yaml
@@ -15,9 +15,17 @@ spec:
       labels:
         app: webhooks
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: webhooks-admin
       containers:
         - name: webhooks
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ "ALL" ]
           command: ["/webhooks"]
           image: quay.io/operator-framework/rukpak:latest
           imagePullPolicy: IfNotPresent

--- a/manifests/apis/webhooks/resources/namespace.yaml
+++ b/manifests/apis/webhooks/resources/namespace.yaml
@@ -1,4 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
   name: system

--- a/manifests/apis/webhooks/resources/namespace.yaml
+++ b/manifests/apis/webhooks/resources/namespace.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/enforce-version: latest
   name: system

--- a/manifests/core/resources/deployment.yaml
+++ b/manifests/core/resources/deployment.yaml
@@ -18,8 +18,16 @@ spec:
         kubectl.kubernetes.io/default-container: manager
     spec:
       serviceAccountName: core-admin
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: kube-rbac-proxy
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ "ALL" ]
           image: quay.io/brancz/kube-rbac-proxy:v0.12.0
           args:
             - "--secure-listen-address=0.0.0.0:8443"
@@ -37,6 +45,10 @@ spec:
             - name: certs
               mountPath: /etc/pki/tls
         - name: manager
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ "ALL" ]
           image: quay.io/operator-framework/rukpak:latest
           imagePullPolicy: IfNotPresent
           command: ["/core"]

--- a/manifests/provisioners/helm/resources/deployment.yaml
+++ b/manifests/provisioners/helm/resources/deployment.yaml
@@ -17,9 +17,17 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: helm-provisioner-admin
       containers:
         - name: kube-rbac-proxy
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ "ALL" ]
           image: quay.io/brancz/kube-rbac-proxy:v0.12.0
           args:
             - "--secure-listen-address=0.0.0.0:8443"
@@ -37,6 +45,10 @@ spec:
             - name: certs
               mountPath: /etc/pki/tls
         - name: manager
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ "ALL" ]
           image: quay.io/operator-framework/rukpak:latest
           imagePullPolicy: IfNotPresent
           command: ["/helm"]


### PR DESCRIPTION
## Summary
This PR brings Pod Security Admission (PSA) standards to RukPak in the form of updating the Namespace manifest (in accordance with the [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-namespace-labels/)) and Deployments. 

> **Note**: The namespace is running in a `baseline` model; However, we eventually want this to be restricted. For the time being I've implemented everything in such a way that `restricted` would be satisfied if we switch over *except* that the unpacker pod is running as root currently. This is because we cannot guarantee, at least at the moment, that the container image that we are going to unpack does not run as root. We'll need to think up a solution for this either here or in the future.