### PR TITLE
.github: Add the go-apidiff workflow

### DIFF
--- a/.github/workflows/go-apidiff.yaml
+++ b/.github/workflows/go-apidiff.yaml
@@ -1,0 +1,25 @@
+name: go-apidiff
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+    - main
+
+jobs:
+  go-apidiff:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '~1.18'
+      id: go
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Run go-apidiff
+      uses: joelanford/go-apidiff@main


### PR DESCRIPTION
Introduces the go-apidiff action that's used throughout the major opreator-framework repositories.

Closes #54 

Signed-off-by: timflannagan <timflannagan@gmail.com>