### PR TITLE
image source: use job for bundle unpacking

### DIFF
--- a/internal/provisioner/helm/controllers/bundle_controller.go
+++ b/internal/provisioner/helm/controllers/bundle_controller.go
@@ -230,9 +230,11 @@ func (r *BundleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&rukpakv1alpha1.Bundle{}, builder.WithPredicates(
 			util.BundleProvisionerFilter(helm.ProvisionerID),
 		)).
-		// The default image source unpacker creates Pod's ownerref'd to its bundle, so
-		// we need to watch pods to ensure we reconcile events coming from these
-		// pods.
-		Watches(&crsource.Kind{Type: &corev1.Pod{}}, util.MapOwneeToOwnerProvisionerHandler(context.Background(), mgr.GetClient(), l, helm.ProvisionerID, &rukpakv1alpha1.Bundle{})).
+		// The default image source unpacker creates a Job, which creates a pod,
+		// resulting in an ownerRef chain from Bundle to Pod. We'll watch pods
+		// directly because we care about events at the granularity of the pod,
+		// and we'll map those pod events back up the ownerRef chain to the root
+		// bundle.
+		Watches(&crsource.Kind{Type: &corev1.Pod{}}, util.MapUnpackPodToBundleHandler(context.Background(), mgr.GetClient(), l, helm.ProvisionerID)).
 		Complete(r)
 }

--- a/internal/provisioner/registry/controllers/bundle_controller.go
+++ b/internal/provisioner/registry/controllers/bundle_controller.go
@@ -274,9 +274,11 @@ func (r *BundleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&rukpakv1alpha1.Bundle{}, builder.WithPredicates(
 			util.BundleProvisionerFilter(registry.ProvisionerID),
 		)).
-		// The default unpacker creates Pod's ownerref'd to its bundle, so
-		// we need to watch pods to ensure we reconcile events coming from these
-		// pods.
-		Watches(&crsource.Kind{Type: &corev1.Pod{}}, util.MapOwneeToOwnerProvisionerHandler(context.Background(), mgr.GetClient(), l, registry.ProvisionerID, &rukpakv1alpha1.Bundle{})).
+		// The default image source unpacker creates a Job, which creates a pod,
+		// resulting in an ownerRef chain from Bundle to Pod. We'll watch pods
+		// directly because we care about events at the granularity of the pod,
+		// and we'll map those pod events back up the ownerRef chain to the root
+		// bundle.
+		Watches(&crsource.Kind{Type: &corev1.Pod{}}, util.MapUnpackPodToBundleHandler(context.Background(), mgr.GetClient(), l, registry.ProvisionerID)).
 		Complete(r)
 }

--- a/internal/source/image.go
+++ b/internal/source/image.go
@@ -5,12 +5,14 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"strings"
 
 	"github.com/nlepage/go-tarfs"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -25,7 +27,7 @@ import (
 type Image struct {
 	Client       client.Client
 	KubeClient   kubernetes.Interface
-	PodNamespace string
+	JobNamespace string
 	UnpackImage  string
 }
 
@@ -39,12 +41,31 @@ func (i *Image) Unpack(ctx context.Context, bundle *rukpakv1alpha1.Bundle) (*Res
 		return nil, fmt.Errorf("bundle source image configuration is unset")
 	}
 
-	pod := &corev1.Pod{}
-	op, err := i.ensureUnpackPod(ctx, bundle, pod)
+	job := &batchv1.Job{}
+	op, err := i.ensureUnpackJob(ctx, bundle, job)
 	if err != nil {
 		return nil, err
-	} else if op == controllerutil.OperationResultCreated || op == controllerutil.OperationResultUpdated || pod.DeletionTimestamp != nil {
+	} else if op == controllerutil.OperationResultCreated || op == controllerutil.OperationResultUpdated || job.DeletionTimestamp != nil {
 		return &Result{State: StatePending}, nil
+	}
+
+	pod, err := i.getPod(ctx, job)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the pod is nil, it means one of two things:
+	//  1. the job controller has not yet created a pod. In this case, we set state to Pending
+	//     and wait for pod watch to feed more requests to the bundle controller reconciler.
+	//  2. the pod was deleted. In this case, we no longer have the pod logs that we need, so
+	//     we'll delete the Job and report an error, which should cause us to create a new Job
+	//     in a subsequent reconciliation.
+	if pod == nil {
+		if job.Status.Active > 0 || job.Status.Failed > 0 || job.Status.Succeeded > 0 {
+			defer i.tryDeleteJob(ctx, job)
+			return nil, errors.New("unpack pod does not exist")
+		}
+		return &Result{State: StatePending, Message: "waiting for unpack pod to be created"}, nil
 	}
 
 	switch phase := pod.Status.Phase; phase {
@@ -53,58 +74,75 @@ func (i *Image) Unpack(ctx context.Context, bundle *rukpakv1alpha1.Bundle) (*Res
 	case corev1.PodRunning:
 		return &Result{State: StateUnpacking}, nil
 	case corev1.PodFailed:
+		defer i.tryDeleteJob(ctx, job)
 		return nil, i.failedPodResult(ctx, pod)
 	case corev1.PodSucceeded:
 		return i.succeededPodResult(ctx, pod)
 	default:
-		return nil, i.handleUnexpectedPod(ctx, pod)
+		defer i.tryDeleteJob(ctx, job)
+		return nil, fmt.Errorf("unexpected pod phase: %v", phase)
 	}
 }
 
-func (i *Image) ensureUnpackPod(ctx context.Context, bundle *rukpakv1alpha1.Bundle, pod *corev1.Pod) (controllerutil.OperationResult, error) {
-	controllerRef := metav1.NewControllerRef(bundle, bundle.GroupVersionKind())
-	automountServiceAccountToken := false
-	pod.SetName(bundle.Name)
-	pod.SetNamespace(i.PodNamespace)
+func (i *Image) ensureUnpackJob(ctx context.Context, bundle *rukpakv1alpha1.Bundle, job *batchv1.Job) (controllerutil.OperationResult, error) {
+	ref := metav1.NewControllerRef(bundle, bundle.GroupVersionKind())
+	refs := []metav1.OwnerReference{*ref}
+	job.SetName(bundle.Name)
+	job.SetNamespace(i.JobNamespace)
 
-	return util.CreateOrRecreate(ctx, i.Client, pod, func() error {
-		pod.SetLabels(map[string]string{
-			util.CoreOwnerKindKey: bundle.Kind,
-			util.CoreOwnerNameKey: bundle.Name,
-		})
-		pod.SetOwnerReferences([]metav1.OwnerReference{*controllerRef})
-		pod.Spec.AutomountServiceAccountToken = &automountServiceAccountToken
-		pod.Spec.RestartPolicy = corev1.RestartPolicyNever
+	bundleLabels := map[string]string{
+		util.CoreOwnerKindKey: bundle.Kind,
+		util.CoreOwnerNameKey: bundle.Name,
+	}
 
-		if len(pod.Spec.InitContainers) != 1 {
-			pod.Spec.InitContainers = make([]corev1.Container, 1)
-		}
+	return util.CreateOrRecreate(ctx, i.Client, job, func() error {
+		job.SetLabels(bundleLabels)
+		job.SetOwnerReferences(refs)
+		job.Spec.ManualSelector = pointer.Bool(true)
+		job.Spec.Selector = metav1.SetAsLabelSelector(bundleLabels)
+		// The goal with BackoffLimit: 0 is to ensure that there's never more than one
+		// pod for a job. If the pod fails, the job controller will not retry. However,
+		// we'll see this and re-spin the entire job with the controller's error
+		// handling backoff.
+		job.Spec.BackoffLimit = pointer.Int32(0)
+		job.Spec.Template.SetLabels(bundleLabels)
 
-		pod.Spec.InitContainers[0].Name = "install-unpacker"
-		pod.Spec.InitContainers[0].Image = i.UnpackImage
-		pod.Spec.InitContainers[0].ImagePullPolicy = corev1.PullIfNotPresent
-		pod.Spec.InitContainers[0].Command = []string{"cp", "-Rv", "/unpack", "/bin/unpack"}
-		pod.Spec.InitContainers[0].VolumeMounts = []corev1.VolumeMount{{Name: "util", MountPath: "/bin"}}
-
-		if len(pod.Spec.Containers) != 1 {
-			pod.Spec.Containers = make([]corev1.Container, 1)
-		}
-
-		pod.Spec.Containers[0].Name = imageBundleUnpackContainerName
-		pod.Spec.Containers[0].Image = bundle.Spec.Source.Image.Ref
-		pod.Spec.Containers[0].Command = []string{"/bin/unpack", "--bundle-dir", "/"}
-		pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{Name: "util", MountPath: "/bin"}}
-
-		addSecurityContext(pod)
-
-		if bundle.Spec.Source.Image.ImagePullSecretName != "" {
-			pod.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: bundle.Spec.Source.Image.ImagePullSecretName}}
-		}
-		pod.Spec.Volumes = []corev1.Volume{
-			{Name: "util", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
-		}
+		mutatePodSpec(&job.Spec.Template.Spec, i.UnpackImage, bundle)
 		return nil
 	})
+}
+
+func mutatePodSpec(podSpec *corev1.PodSpec, unpackImage string, bundle *rukpakv1alpha1.Bundle) {
+	podSpec.AutomountServiceAccountToken = pointer.Bool(false)
+	podSpec.RestartPolicy = corev1.RestartPolicyNever
+
+	if len(podSpec.InitContainers) != 1 {
+		podSpec.InitContainers = make([]corev1.Container, 1)
+	}
+
+	podSpec.InitContainers[0].Name = "install-unpacker"
+	podSpec.InitContainers[0].Image = unpackImage
+	podSpec.InitContainers[0].ImagePullPolicy = corev1.PullIfNotPresent
+	podSpec.InitContainers[0].Command = []string{"cp", "-Rv", "/unpack", "/bin/unpack"}
+	podSpec.InitContainers[0].VolumeMounts = []corev1.VolumeMount{{Name: "util", MountPath: "/bin"}}
+
+	if len(podSpec.Containers) != 1 {
+		podSpec.Containers = make([]corev1.Container, 1)
+	}
+
+	podSpec.Containers[0].Name = imageBundleUnpackContainerName
+	podSpec.Containers[0].Image = bundle.Spec.Source.Image.Ref
+	podSpec.Containers[0].Command = []string{"/bin/unpack", "--bundle-dir", "/"}
+	podSpec.Containers[0].VolumeMounts = []corev1.VolumeMount{{Name: "util", MountPath: "/bin"}}
+
+	addSecurityContext(podSpec)
+
+	if bundle.Spec.Source.Image.ImagePullSecretName != "" {
+		podSpec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: bundle.Spec.Source.Image.ImagePullSecretName}}
+	}
+	podSpec.Volumes = []corev1.Volume{
+		{Name: "util", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+	}
 }
 
 func (i *Image) failedPodResult(ctx context.Context, pod *corev1.Pod) error {
@@ -112,8 +150,8 @@ func (i *Image) failedPodResult(ctx context.Context, pod *corev1.Pod) error {
 	if err != nil {
 		return fmt.Errorf("unpack failed: failed to retrieve failed pod logs: %v", err)
 	}
-	_ = i.Client.Delete(ctx, pod)
-	return fmt.Errorf("unpack failed: %v", string(logs))
+
+	return fmt.Errorf("unpack failed: %v", logs)
 }
 
 func (i *Image) succeededPodResult(ctx context.Context, pod *corev1.Pod) (*Result, error) {
@@ -136,7 +174,7 @@ func (i *Image) succeededPodResult(ctx context.Context, pod *corev1.Pod) (*Resul
 }
 
 func (i *Image) getBundleContents(ctx context.Context, pod *corev1.Pod) (fs.FS, error) {
-	bundleData, err := i.getPodLogs(ctx, pod)
+	podLogs, err := i.getPodLogs(ctx, pod)
 	if err != nil {
 		return nil, fmt.Errorf("get bundle contents: %v", err)
 	}
@@ -144,7 +182,7 @@ func (i *Image) getBundleContents(ctx context.Context, pod *corev1.Pod) (fs.FS, 
 		Content []byte `json:"content"`
 	}{}
 
-	if err := json.Unmarshal(bundleData, &bd); err != nil {
+	if err := json.Unmarshal(podLogs[imageBundleUnpackContainerName], &bd); err != nil {
 		return nil, fmt.Errorf("parse bundle data: %v", err)
 	}
 
@@ -164,22 +202,53 @@ func (i *Image) getBundleImageDigest(pod *corev1.Pod) (string, error) {
 	return "", fmt.Errorf("bundle image digest not found")
 }
 
-func (i *Image) getPodLogs(ctx context.Context, pod *corev1.Pod) ([]byte, error) {
-	logReader, err := i.KubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{}).Stream(ctx)
+func (i *Image) getPod(ctx context.Context, job *batchv1.Job) (*corev1.Pod, error) {
+	podList := corev1.PodList{}
+	ls, err := metav1.LabelSelectorAsSelector(job.Spec.Selector)
 	if err != nil {
-		return nil, fmt.Errorf("get pod logs: %v", err)
-	}
-	defer logReader.Close()
-	buf := &bytes.Buffer{}
-	if _, err := io.Copy(buf, logReader); err != nil {
 		return nil, err
 	}
-	return buf.Bytes(), nil
+	if err := i.Client.List(ctx, &podList, client.InNamespace(job.Namespace), client.MatchingLabelsSelector{Selector: ls}); err != nil {
+		return nil, err
+	}
+	if len(podList.Items) == 0 {
+		return nil, nil
+	}
+	if len(podList.Items) != 1 {
+		return nil, fmt.Errorf("expected exactly 1 job pod, found %d", len(podList.Items))
+	}
+	return &podList.Items[0], nil
 }
 
-func (i *Image) handleUnexpectedPod(ctx context.Context, pod *corev1.Pod) error {
-	_ = i.Client.Delete(ctx, pod)
-	return fmt.Errorf("unexpected pod phase: %v", pod.Status.Phase)
+func (i *Image) getPodLogs(ctx context.Context, pod *corev1.Pod) (map[string][]byte, error) {
+	containerNames := []string{}
+	for _, ic := range pod.Spec.InitContainers {
+		containerNames = append(containerNames, ic.Name)
+	}
+	for _, c := range pod.Spec.Containers {
+		containerNames = append(containerNames, c.Name)
+	}
+
+	podLogs := map[string][]byte{}
+	for _, containerName := range containerNames {
+		if err := func() error {
+			logReader, err := i.KubeClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{}).Stream(ctx)
+			if err != nil {
+				return fmt.Errorf("get pod logs for container %q: %v", containerName, err)
+			}
+			defer logReader.Close()
+			buf := &bytes.Buffer{}
+			if _, err := io.Copy(buf, logReader); err != nil {
+				return fmt.Errorf("read pod logs for container %q: %v", containerName, err)
+			}
+			podLogs[containerName] = buf.Bytes()
+			return nil
+		}(); err != nil {
+			return nil, err
+		}
+	}
+
+	return podLogs, nil
 }
 
 func pendingImagePodResult(pod *corev1.Pod) *Result {
@@ -197,49 +266,61 @@ func pendingImagePodResult(pod *corev1.Pod) *Result {
 // addSecurityContext is responsible for taking a container and defining the
 // relevant security context values. By having a function do this, we can keep
 // that configuration easily consistent and maintainable.
-func addSecurityContext(pod *corev1.Pod) {
-	// Check that pod is defined before proceeding
-	if pod == nil {
+func addSecurityContext(podSpec *corev1.PodSpec) {
+	// Check that pod spec is defined before proceeding
+	if podSpec == nil {
 		return
 	}
 
-	// Add security context for overall pod
-	pod.Spec.SecurityContext = &corev1.PodSecurityContext{
-		// TODO (tyslaton): Address unpacker pod allowing root users for image sources
-		//
-		// In our current implementation, we are creating a pod that uses the image
-		// provided by an image source. This pod is not always guaranteed to run as a
-		// non-root user and thus will fail to initialize if running as root in a PSA
-		// restricted namespace due to violations. As it currently stands, our compliance
-		// with PSA is baseline which allows for pods to run as root users. However,
-		// all RukPak processes and resources, except this unpacker pod for image sources,
-		// are runnable in a PSA restricted environment. We should consider ways to make
-		// this PSA definition either configurable or workable in a restricted namespace.
-		//
-		// See https://github.com/operator-framework/rukpak/pull/539 for more detail.
-		RunAsNonRoot: pointer.Bool(false),
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
+	// TODO (tyslaton): Address unpacker pod allowing root users for image sources
+	//
+	// In our current implementation, we are creating a pod that uses the image
+	// provided by an image source. This pod is not always guaranteed to run as a
+	// non-root user and thus will fail to initialize if running as root in a PSA
+	// restricted namespace due to violations. As it currently stands, our compliance
+	// with PSA is baseline which allows for pods to run as root users. However,
+	// all RukPak processes and resources, except this unpacker pod for image sources,
+	// are runnable in a PSA restricted environment. We should consider ways to make
+	// this PSA definition either configurable or workable in a restricted namespace.
+	//
+	// See https://github.com/operator-framework/rukpak/pull/539 for more detail.
+	if podSpec.SecurityContext == nil {
+		podSpec.SecurityContext = &corev1.PodSecurityContext{}
+	}
+	podSpec.SecurityContext.RunAsNonRoot = pointer.Bool(false)
+
+	if podSpec.SecurityContext.SeccompProfile == nil {
+		podSpec.SecurityContext.SeccompProfile = &corev1.SeccompProfile{}
+	}
+	podSpec.SecurityContext.SeccompProfile.Type = corev1.SeccompProfileTypeRuntimeDefault
+
+	// Add security context for init containers
+	for i := range podSpec.InitContainers {
+		if podSpec.InitContainers[i].SecurityContext == nil {
+			podSpec.InitContainers[i].SecurityContext = &corev1.SecurityContext{}
+		}
+		podSpec.InitContainers[i].SecurityContext.AllowPrivilegeEscalation = pointer.Bool(false)
+
+		if podSpec.InitContainers[i].SecurityContext.Capabilities == nil {
+			podSpec.InitContainers[i].SecurityContext.Capabilities = &corev1.Capabilities{}
+		}
+		podSpec.InitContainers[i].SecurityContext.Capabilities.Drop = []corev1.Capability{"ALL"}
 	}
 
 	// Add security context for containers
-	for i := range pod.Spec.InitContainers {
-		pod.Spec.InitContainers[i].SecurityContext = &corev1.SecurityContext{
-			AllowPrivilegeEscalation: pointer.Bool(false),
-			Capabilities: &corev1.Capabilities{
-				Drop: []corev1.Capability{"ALL"},
-			},
+	for i := range podSpec.Containers {
+		if podSpec.Containers[i].SecurityContext == nil {
+			podSpec.Containers[i].SecurityContext = &corev1.SecurityContext{}
 		}
-	}
+		podSpec.Containers[i].SecurityContext.AllowPrivilegeEscalation = pointer.Bool(false)
 
-	// Add security context for containers
-	for i := range pod.Spec.Containers {
-		pod.Spec.Containers[i].SecurityContext = &corev1.SecurityContext{
-			AllowPrivilegeEscalation: pointer.Bool(false),
-			Capabilities: &corev1.Capabilities{
-				Drop: []corev1.Capability{"ALL"},
-			},
+		if podSpec.Containers[i].SecurityContext.Capabilities == nil {
+			podSpec.Containers[i].SecurityContext.Capabilities = &corev1.Capabilities{}
 		}
+		podSpec.Containers[i].SecurityContext.Capabilities.Drop = []corev1.Capability{"ALL"}
 	}
+}
+
+func (i *Image) tryDeleteJob(ctx context.Context, job *batchv1.Job) {
+	_ = i.Client.Delete(ctx, job, client.PropagationPolicy(metav1.DeletePropagationBackground))
 }

--- a/internal/source/unpacker.go
+++ b/internal/source/unpacker.go
@@ -116,7 +116,7 @@ func NewDefaultUnpacker(mgr ctrl.Manager, namespace, unpackImage string, baseUpl
 		rukpakv1alpha1.SourceTypeImage: &Image{
 			Client:       mgr.GetClient(),
 			KubeClient:   kubeClient,
-			PodNamespace: namespace,
+			JobNamespace: namespace,
 			UnpackImage:  unpackImage,
 		},
 		rukpakv1alpha1.SourceTypeGit: &Git{


### PR DESCRIPTION
It turns out that directly managing pods for image unpacking is more
susceptible to runtime mutation issues (since pods are more likely to
have mutation admission webhooks associated with them than jobs).
Mutating webhooks are problematic for our controller because we need to
reliably detect when a diff between the desired pod and the existing
on-cluster pod is a result of a change triggered via our controller vs.
a change due to some unrelated mutating webhook.

The problem still exists with a Job if the cluster has a mutating
webhook for jobs, but we'll assume for now that the problem is much less
pronounced with jobs than with pods.

NOTE: the pod specs in both jobs and pods are immutable. Therefore, our
controller cannot simply use server-side apply to patch objects back to
desired state. If we could, this problem could be avoided entirely
because we'd never need to detect diffs (we'd just send our SSA patch to
the apiserver and have it do the work).

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>