### PR TITLE
ci: exempt issues placed in the icebox milestone

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -27,5 +27,6 @@ jobs:
           days-before-issue-close: -1
           stale-issue-label: lifecycle/stale
           exempt-issue-labels: lifecycle/frozen
+          exempt-issue-milestones: icebox
       - name: Print outputs
         run: echo ${{ join(steps.stale.outputs.*, ',') }}


### PR DESCRIPTION
Adding a small change that makes it so issues in the `icebox` milestone no longer get updated by the `stale` action. The main thought here is that, since these issues are placed in the `icebox`, they shouldn't be life-cycled as normal.

Alternatively, we could close this issue and the `icebox` milestone and apply all current `icebox` issues with the `lifecycle/frozen` label; this would have the same effect as this PR. 