### PR TITLE
ci(stale): update to run twice daily and remove failing print step"

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -2,8 +2,8 @@ name: stale
 on:
   workflow_dispatch:
   schedule:
-    # The start of everyday
-    - cron: '0 0 * * *'
+    # The start of everyday and at hour 12
+    - cron: '00 00,12 * * *'
 
 jobs:
   stale:
@@ -27,5 +27,3 @@ jobs:
           days-before-issue-close: -1
           stale-issue-label: lifecycle/stale
           exempt-issue-labels: lifecycle/frozen
-      - name: Print outputs
-        run: echo ${{ join(steps.stale.outputs.*, ',') }}


### PR DESCRIPTION
Github rate limits their API and, since this action can do a large number of actions in a short span of time, it defaults to 30 actions in a single run. This is fine, but the only problem is that if several issues are stale it will not get to them. As a result, this commit updates the action to run twice daily which should help the issue.

Additionally, this commit removes a failing print step from the job.