### PR TITLE
image source: use applyconfiguration with server-side apply

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	k8s.io/apimachinery v0.24.2
 	k8s.io/cli-runtime v0.24.2
 	k8s.io/client-go v0.24.2
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/controller-runtime v0.12.3
 	sigs.k8s.io/yaml v1.3.0
 )
@@ -170,6 +169,7 @@ require (
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	k8s.io/kubectl v0.24.1 // indirect
+	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	oras.land/oras-go v1.1.0 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/kustomize/api v0.11.4 // indirect


### PR DESCRIPTION
This is another take on #555 that makes use of applyconfigurations and server-side apply to "apply or re-create" unpack pods.

This should solve problems that we're seeing with our existing diff comparisons where we do not handle mutations performed by unrelated webhooks.

This should be more resilient than a "hash the pod struct" approach, which is susceptible to hash changes when the Pod struct changes. This approach should theoretically not result in an unpack pod respin unless something in our apply configuration actually changed.

I tested this on a cluster that performs pod mutations and verified that Bundles are able to be successfully unpacked, and the controller does not continuously re-create the unpack pod.

Closes #560 

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>