### PR TITLE
fix: update stale action to have more capacity to process items

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   schedule:
     # The start of everyday and at hour 12
-    - cron: '00 00,12 * * *'
+    - cron: '00 00 * * *'
 
 jobs:
   stale:
@@ -12,9 +12,12 @@ jobs:
       - uses: actions/stale@v5.1.1
         id: stale
         with:
+          # Overall configuration
+          operations-per-run: 100
+
           # PR configuration
           days-before-pr-stale: 30
-          stale-pr-message: 'This PR has become stale because it has been open for 30 days with no activity. Please provide an update, merge, close, or add the lifecycle/frozen label to this PR before it is automatically closed.'
+          stale-pr-message: 'This PR has become stale because it has been open for 30 days with no activity. Please update this PR or remove the `lifecycle/stale` label before it is automatically closed in 30 days. Adding the `lifecycle/frozen` label will cause this PR to ignore lifecycle events.'
           days-before-pr-close: 30
           close-pr-message: 'This PR has been closed as no updates were detected after 30 days of being stale. Please feel free to reopen this PR if necessary.'
           stale-pr-label: lifecycle/stale
@@ -23,7 +26,7 @@ jobs:
 
           # Issue configuration
           days-before-issue-stale: 60
-          stale-issue-message: 'This issue has become stale because it has been open 60 days with no activity. The maintainers of this repo will remove this label during issue triage. Adding the lifecycle/frozen label will cause this issue to ignore lifecycle events.'
+          stale-issue-message: 'This issue has become stale because it has been open 60 days with no activity. The maintainers of this repo will remove this label during issue triage or it will be removed automatically after an update. Adding the `lifecycle/frozen` label will cause this issue to ignore lifecycle events.'
           days-before-issue-close: -1
           stale-issue-label: lifecycle/stale
           exempt-issue-labels: lifecycle/frozen


### PR DESCRIPTION
## Summary
Right now the bot is having a hard time processing our backlog due to its size. By default, there are 30 operations allowed before it stops attempting to process things to avoid rate limiting. We can get around this by increasing the amount of operations allowed per run. This has more potential for rate limiting, but should be fine in off hours.

In addition to adding these changes, this commit sets the the action only run once per day and updates the messaging it leaves when marking issues/prs as stale.

## Notes
- Should we consider moving to another bot to perform this work? It seems there are some natural limitations around this.
- The more we triage our issues, the less operations that will need to be performed.

Relates to #546 