### PR TITLE
kustomize provisioner

### DIFF
--- a/.goreleaser.template.yml
+++ b/.goreleaser.template.yml
@@ -34,6 +34,18 @@ builds:
       - s390x
     ldflags:
       - -X {{ .Env.PKG }}.GitCommit={{ .ShortCommit }}
+  - id: kustomize
+    main: ./cmd/kustomize
+    binary: kustomize
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+      - ppc64le
+      - s390x
+    ldflags:
+      - -X {{ .Env.PKG }}.GitCommit={{ .ShortCommit }}
   - id: core
     main: ./cmd/core
     binary: core
@@ -146,6 +158,7 @@ release:
     kubectl apply -f https://github.com/operator-framework/rukpak/releases/download/{{ .Tag }}/rukpak.yaml
     kubectl wait --for=condition=Available --namespace=rukpak-system deployment/core --timeout=60s
     kubectl wait --for=condition=Available --namespace=rukpak-system deployment/helm-provisioner --timeout=60s
+    kubectl wait --for=condition=Available --namespace=rukpak-system deployment/kustomize-provisioner --timeout=60s
     kubectl wait --for=condition=Available --namespace=rukpak-system deployment/rukpak-webhooks --timeout=60s
     kubectl wait --for=condition=Available --namespace=crdvalidator-system deployment/crd-validation-webhook --timeout=60s
     ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,6 @@ COPY unpack unpack
 COPY webhooks webhooks
 COPY crdvalidator crdvalidator
 COPY rukpakctl rukpakctl
+COPY kustomize kustomize
 
 EXPOSE 8080

--- a/cmd/kustomize/main.go
+++ b/cmd/kustomize/main.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto/x509"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/gorilla/handlers"
+	helmclient "github.com/operator-framework/helm-operator-plugins/pkg/client"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	crfinalizer "sigs.k8s.io/controller-runtime/pkg/finalizer"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	"github.com/operator-framework/rukpak/internal/finalizer"
+	"github.com/operator-framework/rukpak/internal/provisioner/bundle"
+	"github.com/operator-framework/rukpak/internal/provisioner/bundledeployment"
+	"github.com/operator-framework/rukpak/internal/provisioner/kustomize"
+	"github.com/operator-framework/rukpak/internal/source"
+	"github.com/operator-framework/rukpak/internal/storage"
+	"github.com/operator-framework/rukpak/internal/uploadmgr"
+	"github.com/operator-framework/rukpak/internal/util"
+	"github.com/operator-framework/rukpak/internal/version"
+)
+
+var (
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+	utilruntime.Must(rukpakv1alpha1.AddToScheme(scheme))
+	//+kubebuilder:scaffold:scheme
+}
+
+func main() {
+	var (
+		httpBindAddr                string
+		httpExternalAddr            string
+		bundleCAFile                string
+		enableLeaderElection        bool
+		probeAddr                   string
+		systemNamespace             string
+		unpackImage                 string
+		baseUploadManagerURL        string
+		rukpakVersion               bool
+		provisionerStorageDirectory string
+		uploadStorageDirectory      string
+		uploadStorageSyncInterval   time.Duration
+	)
+	flag.StringVar(&httpBindAddr, "http-bind-address", ":8080", "The address the http server binds to.")
+	flag.StringVar(&httpExternalAddr, "http-external-address", "http://localhost:8080", "The external address at which the http server is reachable.")
+	flag.StringVar(&bundleCAFile, "bundle-ca-file", "", "The file containing the certificate authority for connecting to bundle content servers.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&systemNamespace, "system-namespace", "rukpak-system", "Configures the namespace that gets used to deploy system resources.")
+	flag.StringVar(&unpackImage, "unpack-image", "quay.io/operator-framework/rukpak:latest", "Configures the container image that gets used to unpack Bundle contents.")
+	flag.StringVar(&baseUploadManagerURL, "base-upload-manager-url", "", "The base URL from which to fetch uploaded bundles.")
+	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+		"Enable leader election for controller manager. "+
+			"Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&rukpakVersion, "version", false, "Displays rukpak version information")
+	flag.StringVar(&provisionerStorageDirectory, "provisioner-storage-dir", storage.DefaultBundleCacheDir, "The directory that is used to store bundle contents.")
+	flag.StringVar(&uploadStorageDirectory, "upload-storage-dir", uploadmgr.DefaultBundleCacheDir, "The directory that is used to store bundle uploads.")
+	flag.DurationVar(&uploadStorageSyncInterval, "upload-storage-sync-interval", time.Minute, "Interval on which to garbage collect unused uploaded bundles")
+	opts := zap.Options{
+		Development: true,
+	}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	if rukpakVersion {
+		fmt.Printf("Git commit: %s\n", version.String())
+		os.Exit(0)
+	}
+
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	setupLog.Info("starting up the core controllers and servers", "git commit", version.String(), "unpacker image", unpackImage)
+
+	dependentRequirement, err := labels.NewRequirement(util.CoreOwnerKindKey, selection.In, []string{rukpakv1alpha1.BundleKind, rukpakv1alpha1.BundleDeploymentKind})
+	if err != nil {
+		setupLog.Error(err, "unable to create dependent label selector for cache")
+		os.Exit(1)
+	}
+	dependentSelector := labels.NewSelector().Add(*dependentRequirement)
+
+	cfg := ctrl.GetConfigOrDie()
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:                 scheme,
+		MetricsBindAddress:     httpBindAddr,
+		Port:                   9443,
+		HealthProbeBindAddress: probeAddr,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "core.rukpak.io",
+		NewCache: cache.BuilderWithOptions(cache.Options{
+			SelectorsByObject: cache.SelectorsByObject{
+				&rukpakv1alpha1.BundleDeployment{}: {},
+				&rukpakv1alpha1.Bundle{}:           {},
+			},
+			DefaultSelector: cache.ObjectSelector{
+				Label: dependentSelector,
+			},
+		}),
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to create manager")
+		os.Exit(1)
+	}
+
+	ns := util.PodNamespace(systemNamespace)
+	storageURL, err := url.Parse(fmt.Sprintf("%s/bundles/", httpExternalAddr))
+	if err != nil {
+		setupLog.Error(err, "unable to parse bundle content server URL")
+		os.Exit(1)
+	}
+
+	localStorage := &storage.LocalDirectory{
+		RootDirectory: provisionerStorageDirectory,
+		URL:           *storageURL,
+	}
+
+	var rootCAs *x509.CertPool
+	if bundleCAFile != "" {
+		var err error
+		if rootCAs, err = util.LoadCertPool(bundleCAFile); err != nil {
+			setupLog.Error(err, "unable to parse bundle certificate authority file")
+			os.Exit(1)
+		}
+	}
+
+	httpLoader := storage.NewHTTP(
+		storage.WithRootCAs(rootCAs),
+		storage.WithBearerToken(cfg.BearerToken),
+	)
+	bundleStorage := storage.WithFallbackLoader(localStorage, httpLoader)
+
+	// NOTE: AddMetricsExtraHandler isn't actually metrics-specific. We can run
+	// whatever handlers we want on the existing webserver that
+	// controller-runtime runs when MetricsBindAddress is configured on the
+	// manager.
+	if err := mgr.AddMetricsExtraHandler("/bundles/", httpLogger(localStorage)); err != nil {
+		setupLog.Error(err, "unable to add bundles http handler to manager")
+		os.Exit(1)
+	}
+	if err := mgr.AddMetricsExtraHandler("/uploads/", httpLogger(uploadmgr.NewUploadHandler(mgr.GetClient(), uploadStorageDirectory))); err != nil {
+		setupLog.Error(err, "unable to add uploads http handler to manager")
+		os.Exit(1)
+	}
+
+	// This finalizer logic MUST be co-located with this main
+	// controller logic because it deals with cleaning up bundle data
+	// from the bundle cache when the bundles are deleted. The
+	// consequence is that this process MUST remain running in order
+	// to process DELETE events for bundles that include this finalizer.
+	// If this process is NOT running, deletion of such bundles will
+	// hang until $something removes the finalizer.
+	//
+	// If the bundle cache is backed by a storage implementation that allows
+	// multiple writers from different processes (e.g. a ReadWriteMany volume or
+	// an S3 bucket), we could have separate processes for finalizer handling
+	// and the primary provisioner controllers. For now, the assumption is
+	// that we are not using such an implementation.
+	bundleFinalizers := crfinalizer.NewFinalizers()
+	if err := bundleFinalizers.Register(finalizer.DeleteCachedBundleKey, &finalizer.DeleteCachedBundle{Storage: bundleStorage}); err != nil {
+		setupLog.Error(err, "unable to register finalizer", "finalizerKey", finalizer.DeleteCachedBundleKey)
+		os.Exit(1)
+	}
+
+	unpacker, err := source.NewDefaultUnpacker(mgr, ns, unpackImage, baseUploadManagerURL, rootCAs)
+	if err != nil {
+		setupLog.Error(err, "unable to setup bundle unpacker")
+		os.Exit(1)
+	}
+
+	commonBundleProvisionerOptions := []bundle.Option{
+		bundle.WithUnpacker(unpacker),
+		bundle.WithFinalizers(bundleFinalizers),
+		bundle.WithStorage(bundleStorage),
+	}
+
+	cfgGetter := helmclient.NewActionConfigGetter(mgr.GetConfig(), mgr.GetRESTMapper(), mgr.GetLogger())
+	acg := helmclient.NewActionClientGetter(cfgGetter)
+	commonBDProvisionerOptions := []bundledeployment.Option{
+		bundledeployment.WithReleaseNamespace(ns),
+		bundledeployment.WithActionClientGetter(acg),
+		bundledeployment.WithStorage(bundleStorage),
+	}
+
+	if err := bundle.SetupProvisioner(mgr, append(
+		commonBundleProvisionerOptions,
+		bundle.WithProvisionerID(kustomize.ProvisionerID),
+		bundle.WithHandler(bundle.HandlerFunc(kustomize.HandleBundle)),
+	)...); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", rukpakv1alpha1.BundleKind, "provisionerID", kustomize.ProvisionerID)
+		os.Exit(1)
+	}
+
+	if err := bundledeployment.SetupProvisioner(mgr, append(
+		commonBDProvisionerOptions,
+		bundledeployment.WithProvisionerID(kustomize.ProvisionerID),
+		bundledeployment.WithHandler(bundledeployment.HandlerFunc(kustomize.HandleBundleDeployment)),
+	)...); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", rukpakv1alpha1.BundleDeploymentKind, "provisionerID", kustomize.ProvisionerID)
+		os.Exit(1)
+	}
+	//+kubebuilder:scaffold:builder
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up ready check")
+		os.Exit(1)
+	}
+
+	setupLog.Info("starting manager")
+	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
+}
+
+func httpLogger(h http.Handler) http.Handler {
+	return handlers.CustomLoggingHandler(nil, h, func(_ io.Writer, params handlers.LogFormatterParams) {
+		ctrl.Log.WithName("http").Info("responded", "method", params.Request.Method, "status", params.StatusCode, "url", params.URL.String(), "size", params.Size)
+	})
+}

--- a/docs/bundles/kustomize.md
+++ b/docs/bundles/kustomize.md
@@ -1,0 +1,30 @@
+# Kustomize Bundle Spec
+
+## Overview
+
+This document is meant to define the `Kustomize` bundle format as a reference for those publishing `Kustomize` bundles
+for use with RukPak. For more information on the concept of a bundle, click [here](https://github.com/operator-framework/rukpak#bundle).
+
+A Kustomize bundle is a [Kustomize](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/).
+The Kustomize can be created by [Kustomize create](https://kubectl.docs.kubernetes.io/references/kustomize/cmd/create/).
+
+The current Kustomize bundle format name is the `Kustomize+v0` that
+combines the type of bundle (Kustomize) with the current format version (v0).
+
+## Example
+
+For example, below is an example of a file tree in a "Kustomize+v0" bundle.
+
+```tree
+<bundleRoot> 
+├── kustomization.yaml
+├── staging
+│   └── kustomization.yaml
+├── dev
+│   └── kustomization.yaml
+├── production
+│   └── kustomization.yaml
+└── base
+    ├── kustomization.yaml
+    └── pod.yaml
+```

--- a/docs/provisioners/kustomize.md
+++ b/docs/provisioners/kustomize.md
@@ -1,0 +1,355 @@
+# kustomize Provisioner
+
+## Summary
+
+The `kustomize` provisioner is one of the [provisioners](https://github.com/operator-framework/rukpak/tree/main/internal/provisioner) of RukPak.
+It instantiates a given `kustomize+v0` bundle onto a cluster and then install the generated resources
+on the cluster.  The `kustomize+v0` bundle is a [Kustomization](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/).
+It does so by reconciling `Bundle` and `BundleDeployment` types that have
+the `spec.provisionerClassName` field set to `core-rukpak-io-kustomize`. This field must be set to the correct provisioner
+name in order for the `kustomize` provisioner to see and interact with the bundle.
+
+Supported source types for a kustomize bundle currently include the following:
+
+* A container image
+* A directory in a git repository
+* An [http](../sources/http.md) url
+* An [upload](../uploading-bundles.md) artifact
+
+Additional source types, such as a local volume are on the roadmap. These source types
+all present the same content, a directory containing a kustomize, in a different ways.
+
+### Install and apply a specific version of a `kustomize+v0` bundle
+
+> :warning: Anyone with the ability to create or update BundleDeployment objects can become a cluster admin. It's important
+> to limit access to this API via RBAC to only those that explicitly require access, as well as audit your bundles to
+> ensure the content being installed on-cluster is as-expected and secure.
+
+The `kustomize` provisioner can install and make available a specific `kustomize+v0` bundle in the cluster.
+
+Simply create a `BundleDeployment` resource that contains the desired specification of a Bundle resource.
+The `kustomize` provisioner will retrieve the referred kustomization files and instantiate the Bundle onto the cluster, and eventually install the generated resources
+ on the cluster.
+
+```yaml
+apiVersion: core.rukpak.io/v1alpha1
+kind: BundleDeployment
+metadata:
+  name: my-kustomize
+spec:
+  provisionerClassName: core-rukpak-io-kustomize
+  config:
+    path: dev
+  template:
+    metadata:
+      labels:
+        app: my-kustomize
+    spec:
+      provisionerClassName: core-rukpak-io-kustomize
+      source:
+        git:
+          ref:
+            branch: main
+          repository: https://github.com/akihikokuroda/kustomize
+          directory: ./manifests
+        type: git
+```
+
+For the target purpose, the path to the target purpose directory is specified in the `config`.  It is used during the kustomization of the manifest files.
+
+> Note: the generated Bundle will contain the BundleDeployment's metadata.Name as a prefix, followed by
+> the hash of the provided template.
+
+As the bundle content is retrieved and stored onto the cluster via the defined storage mechanism, the bundle status
+will be updated to Unpacked, indicating that all its contents have been stored on-cluster.
+
+```console
+$ kubectl get bundle -l app=my-kustomize
+NAME                  TYPE   PHASE      AGE
+my-kustomize-fd5xcx   git    Unpacked   17s
+```
+
+Now that the bundle has been unpacked, the provisioner is able to create the resources in the bundle on the cluster.
+These resources will be owned by the corresponding BundleDeployment. Creating the BundleDeployment on-cluster results in an
+InstallationSucceeded Phase if the application of resources to the cluster was successful.
+
+```console
+$ kubectl get bundledeployment my-kustomize
+NAME           ACTIVE BUNDLE         INSTALL STATE           AGE
+my-kustomize   my-kustomize-fd5xcx   InstallationSucceeded   68s
+```
+
+> Note: Creation of more than one BundleDeployment from the same Bundle will likely result in an error.
+
+## Quick Start
+
+### Setup
+
+#### Install RukPak for expertiment
+
+To experiment with the `kustomize` provisioner locally, take the following steps to
+create a local [kind](https://kind.sigs.k8s.io/) cluster and deploy the provisioner onto it:
+
+```bash
+# Clone the repository
+git clone https://github.com/operator-framework/rukpak
+
+# Navigate to the repository
+cd rukpak
+
+# Start a local kind cluster then build and deploy the provisioner onto it
+make run
+```
+
+### Installing the sample
+
+From there, create some Bundles and BundleDeployment types to see the provisioner in action. For an example kustomize to
+use, the [akihikokuroda/kustomize](https://github.com/akihikokuroda/kustomize) is a good example.
+
+Create the sample BundleDeployment referencing the desired sample kustomize in Bundle configuration:
+
+```bash
+kubectl apply -f -<<EOF
+apiVersion: core.rukpak.io/v1alpha1
+kind: BundleDeployment
+metadata:
+  name: my-kustomize
+spec:
+  provisionerClassName: core-rukpak-io-kustomize
+  config:
+    path: dev
+  template:
+    metadata:
+      labels:
+        app: my-kustomize
+    spec:
+      provisionerClassName: core-rukpak-io-kustomize
+      source:
+        git:
+          ref:
+            branch: main
+          repository: https://github.com/akihikokuroda/kustomize
+          directory: ./manifests
+        type: git
+EOF
+```
+
+A message saying that the BundleDeployment is created should be returned:
+
+```console
+$ kubectl apply -f -<<EOF
+...
+EOF
+bundledeployment.core.rukpak.io/my-kustomize created
+```
+
+Next, check the Bundle status via:
+
+```bash
+kubectl get bundle -l app=my-kustomize
+```
+
+Eventually the Bundle should show up as Unpacked:
+
+```console
+$ kubectl get bundle -l app=my-kustomize
+NAME                  TYPE   PHASE      AGE
+my-kustomize-fd5xcx   git    Unpacked   44s
+```
+
+Check the BundleDeployment status to ensure that the installation was successful:
+
+```bash
+kubectl get bundledeployment my-kustomize
+```
+
+A successful installation will show InstallationSucceeded as the `INSTALL STATE`:
+
+```console
+$ kubectl get bundledeployment my-kustomize
+NAME           ACTIVE BUNDLE         INSTALL STATE           AGE
+my-kustomize   my-kustomize-fd5xcx   InstallationSucceeded   3m15s
+```
+
+From there, ensure that the generated resources are installed and the operator is present on the cluster:
+
+```bash
+# Check the dev-myapp-pod pod
+kubectl get pod dev-myapp-pod
+```
+
+The pod should show ready and available:
+
+```console
+$ kubectl get pod dev-myapp-pod
+NAME            READY   STATUS    RESTARTS   AGE
+dev-myapp-pod   1/1     Running   0          6m2s
+```
+
+This means the operator should be successfully installed.
+
+Delete BundleDeployment for the next step
+```bash
+kubectl delete bundledeployment my-kustomize
+```
+
+```console
+bundledeployment.core.rukpak.io "my-kustomize" deleted
+```
+
+### Update the target purpose path
+
+Change this a value in the values file.  Update the `dev` to `staging`
+
+```bash
+kubectl apply -f -<<EOF
+apiVersion: core.rukpak.io/v1alpha1
+kind: BundleDeployment
+metadata:
+  name: my-kustomize
+spec:
+  provisionerClassName: core-rukpak-io-kustomize
+  config:
+    path: staging
+  template:
+    metadata:
+      labels:
+        app: my-kustomize
+    spec:
+      provisionerClassName: core-rukpak-io-kustomize
+      source:
+        git:
+          ref:
+            branch: main
+          repository: https://github.com/akihikokuroda/kustomize
+          directory: ./manifests
+        type: git
+EOF
+```
+
+```console
+bundledeployment.core.rukpak.io/my-kustomize created
+```
+
+Check the name of the pod
+
+```bash
+kubectl get pod
+```
+
+```console
+NAME                                    READY   STATUS    RESTARTS   AGE
+core-5659bb87b6-6vsnn                   2/2     Running   0          5h46m
+helm-provisioner-ff7c54d6-29rwh         2/2     Running   0          5h46m
+kustomize-provisioner-f56d7695b-l26nj   2/2     Running   0          4h3m
+rukpak-webhooks-59c548fcd6-6phc5        1/1     Running   0          5h46m
+stag-myapp-pod                          1/1     Running   0          62s
+```
+
+Now the name of the pod is `stag-myapp-pod`
+
+### Upgrade the kustomize resorces
+
+```bash
+kubectl apply -f -<<EOF
+apiVersion: core.rukpak.io/v1alpha1
+kind: BundleDeployment
+metadata:
+  name: my-kustomize
+spec:
+  provisionerClassName: core-rukpak-io-kustomize
+  config:
+    path: staging
+  template:
+    metadata:
+      labels:
+        app: my-kustomize
+    spec:
+      provisionerClassName: core-rukpak-io-kustomize
+      source:
+        git:
+          ref:
+            branch: v1
+          repository: https://github.com/akihikokuroda/kustomize
+          directory: ./manifests
+        type: git
+EOF
+```
+
+```console
+bundledeployment.core.rukpak.io/my-kustomize configured
+```
+
+Check the name of the pod
+
+```bash
+kubectl get pod
+```
+
+```console
+$ kubectl get pod
+NAME                                    READY   STATUS    RESTARTS   AGE
+core-5659bb87b6-6vsnn                   2/2     Running   0          5h58m
+helm-provisioner-ff7c54d6-29rwh         2/2     Running   0          5h58m
+kustomize-provisioner-f56d7695b-l26nj   2/2     Running   0          4h15m
+rukpak-webhooks-59c548fcd6-6phc5        1/1     Running   0          5h58m
+stag-myapp-pod-v1                       1/1     Running   0          48s
+```
+
+Now the name of the pod is `stag-myapp-pod-v1`
+
+### Reconcile deployed resources
+
+The `kustomize` provisioner continually reconciles BundleDeployment resources. Next, let's try deleting the stag-myapp-pod-v1 pod:
+
+```bash
+kubectl delete pod stag-myapp-pod-v1
+```
+
+A message saying the deployment was deleted should be returned:
+
+```console
+$ kubectl delete pod stag-myapp-pod-v1
+pod "stag-myapp-pod-v1" deleted
+```
+
+The provisioner ensures that all resources required for the BundleDeployment to run are accounted for on-cluster.
+So if we check for the pod again, it will be back on the cluster:
+
+
+```bash
+kubectl get pod stag-myapp-pod-v1
+```
+
+```console
+$ kubectl get pod   stag-myapp-pod-v1
+NAME                READY   STATUS    RESTARTS   AGE
+stag-myapp-pod-v1   1/1     Running   0          64s
+```
+
+### Deleting the sample chart and Local Kind Cluster
+
+To clean up from the installation, simply remove the BundleDeployment from the cluster. This will remove all references
+resources including the deployment, RBAC, and the operator namespace.
+
+> Note: There's no need to manually clean up the Bundles that were generated from a BundleDeployment resource. The plain provisioner places owner references on any Bundle that's generated from an individual BundleDeployment resource.
+
+```bash
+# Delete the combo BundleDeployment
+kubectl delete bundledeployments.core.rukpak.io my-kustomize
+```
+
+A message should show that the BundleDeployment was deleted and now the cluster state is the same as it was
+prior to installing the operator.
+
+```console
+$ kubectl delete bundledeployments.core.rukpak.io my-kustomize
+bundledeployment.core.rukpak.io "my-kustomize" deleted
+```
+
+To stop and clean up the kind cluster, delete it:
+
+```bash
+# Clean up kind cluster
+kind delete clusters rukpak
+```

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,8 @@ require (
 	k8s.io/cli-runtime v0.25.0
 	k8s.io/client-go v0.25.0
 	sigs.k8s.io/controller-runtime v0.13.0
+	sigs.k8s.io/kustomize/api v0.12.1
+	sigs.k8s.io/kustomize/kyaml v0.13.9
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -173,7 +175,5 @@ require (
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed // indirect
 	oras.land/oras-go v1.1.0 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
-	sigs.k8s.io/kustomize/api v0.12.1 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )

--- a/internal/provisioner/kustomize/kustomize.go
+++ b/internal/provisioner/kustomize/kustomize.go
@@ -1,0 +1,183 @@
+package kustomize
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"path/filepath"
+
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apimachyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/kustomize/api/krusty"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+	"sigs.k8s.io/yaml"
+
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	"github.com/operator-framework/rukpak/internal/util"
+)
+
+const (
+	// ProvisionerID is the unique kustomize provisioner ID
+	ProvisionerID = "core-rukpak-io-kustomize"
+)
+
+func HandleBundle(ctx context.Context, fsys fs.FS, bundle *rukpakv1alpha1.Bundle) (fs.FS, error) {
+	err := verifyObjects(".", fsys)
+	if err != nil {
+		return nil, err
+	}
+	return fsys, nil
+}
+
+func HandleBundleDeployment(ctx context.Context, fsys fs.FS, bd *rukpakv1alpha1.BundleDeployment) (*chart.Chart, chartutil.Values, error) {
+	desiredObjects, err := loadBundle(fsys, bd)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	chrt := &chart.Chart{
+		Metadata: &chart.Metadata{},
+	}
+	for _, obj := range desiredObjects {
+		jsonData, err := yaml.Marshal(obj)
+		if err != nil {
+			return nil, nil, err
+		}
+		hash := sha256.Sum256(jsonData)
+		chrt.Templates = append(chrt.Templates, &chart.File{
+			Name: fmt.Sprintf("object-%x.yaml", hash[0:8]),
+			Data: jsonData,
+		})
+	}
+	return chrt, nil, nil
+}
+
+func verifyObjects(path string, bundleFS fs.FS) error {
+	entries, err := fs.ReadDir(bundleFS, path)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			// Symbolic link is skipped to avoid infinite loop
+			if (e.Type() & fs.ModeSymlink) != 0 {
+				continue
+			}
+			err := verifyObjects(filepath.Join(path, e.Name()), bundleFS)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+		fileData, err := fs.ReadFile(bundleFS, filepath.Join(path, e.Name()))
+		if err != nil {
+			return err
+		}
+		var data interface{}
+		err = yaml.Unmarshal(fileData, &data)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func loadBundle(fsys fs.FS, bd *rukpakv1alpha1.BundleDeployment) ([]client.Object, error) {
+	bundleFileSystem, err := fStoFileSystem(fsys)
+	if err != nil {
+		return nil, fmt.Errorf("kustomize file copy error: %v", err)
+	}
+	path, err := loadPath(bd)
+	if err != nil {
+		return nil, fmt.Errorf("path for kustomize is not specified: %v", err)
+	}
+	kustomizer := krusty.MakeKustomizer(krusty.MakeDefaultOptions())
+	res, err := kustomizer.Run(bundleFileSystem, path)
+	if err != nil {
+		return nil, fmt.Errorf("kustomize error: %v", err)
+	}
+	fileData, err := res.AsYaml()
+	if err != nil {
+		return nil, fmt.Errorf("kustomize asyaml error: %v", err)
+	}
+
+	var objects []client.Object
+	dec := apimachyaml.NewYAMLOrJSONDecoder(bytes.NewReader(fileData), 1024)
+	for {
+		obj := unstructured.Unstructured{}
+		err := dec.Decode(&obj)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read error: %v", err)
+		}
+		objects = append(objects, &obj)
+	}
+
+	objs := make([]client.Object, 0, len(objects))
+	for _, obj := range objects {
+		obj := obj
+		obj.SetLabels(util.MergeMaps(obj.GetLabels(), map[string]string{
+			util.CoreOwnerKindKey: rukpakv1alpha1.BundleDeploymentKind,
+			util.CoreOwnerNameKey: bd.GetName(),
+		}))
+		objs = append(objs, obj)
+	}
+	return objs, nil
+}
+
+func loadPath(bd *rukpakv1alpha1.BundleDeployment) (string, error) {
+	data, err := bd.Spec.Config.MarshalJSON()
+	if err != nil {
+		return "", err
+	}
+	var config map[string]string
+	err = json.Unmarshal(data, &config)
+	if err != nil {
+		return "", err
+	}
+	path, ok := config["path"]
+	// When path is not specified, bundle root directory is used as the path
+	if !ok {
+		path = "."
+	}
+	return path, nil
+}
+
+func fStoFileSystem(infs fs.FS) (filesys.FileSystem, error) {
+	memfs := filesys.MakeFsInMemory()
+	err := fs.WalkDir(infs, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return fmt.Errorf("kustomize copy file error: %v", err)
+		}
+		if d.IsDir() {
+			return nil
+		}
+		file, err := memfs.Create(path)
+		if err != nil {
+			return fmt.Errorf("kustomize create file error: %v", err)
+		}
+		fileData, err := fs.ReadFile(infs, path)
+		if err != nil {
+			return fmt.Errorf("kustomize read file error: %v", err)
+		}
+		_, err = file.Write(fileData)
+		if err != nil {
+			return fmt.Errorf("kustomize write file error: %v", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return memfs, nil
+}

--- a/manifests/provisioners/kustomization.yaml
+++ b/manifests/provisioners/kustomization.yaml
@@ -1,3 +1,4 @@
 bases:
 - ./helm
+- ./kustomize
 

--- a/manifests/provisioners/kustomize/kustomization.yaml
+++ b/manifests/provisioners/kustomize/kustomization.yaml
@@ -1,0 +1,21 @@
+resources:
+  - resources/certificate.yaml
+  - resources/cluster_role.yaml
+  - resources/cluster_role_binding.yaml
+  - resources/deployment.yaml
+  - resources/service.yaml
+  - resources/serviceaccount.yaml
+
+vars:
+  - name: KUSTOMIZE_PROVISIONER_SERVICE_NAMESPACE # namespace of the service
+    objref:
+      kind: Service
+      version: v1
+      name: kustomize-provisioner
+    fieldref:
+      fieldpath: metadata.namespace
+  - name: KUSTOMIZE_PROVISIONER_SERVICE_NAME
+    objref:
+      kind: Service
+      version: v1
+      name: kustomize-provisioner

--- a/manifests/provisioners/kustomize/resources/certificate.yaml
+++ b/manifests/provisioners/kustomize/resources/certificate.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kustomize-provisioner
+  namespace: rukpak-system
+spec:
+  secretName: kustomize-provisioner-cert
+  dnsNames:
+    - $(KUSTOMIZE_PROVISIONER_SERVICE_NAME).$(KUSTOMIZE_PROVISIONER_SERVICE_NAMESPACE).svc
+    - $(KUSTOMIZE_PROVISIONER_SERVICE_NAME).$(KUSTOMIZE_PROVISIONER_SERVICE_NAMESPACE).svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: rukpak-ca-issuer

--- a/manifests/provisioners/kustomize/resources/cluster_role.yaml
+++ b/manifests/provisioners/kustomize/resources/cluster_role.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kustomize-provisioner-admin
+rules:
+- nonResourceURLs:
+  - /bundles/*
+  - /uploads/*
+  verbs:
+  - get
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundledeployments
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundledeployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundledeployments/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundles
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundles/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - core.rukpak.io
+  resources:
+  - bundles/status
+  verbs:
+  - patch
+  - update

--- a/manifests/provisioners/kustomize/resources/cluster_role_binding.yaml
+++ b/manifests/provisioners/kustomize/resources/cluster_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kustomize-provisioner-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kustomize-provisioner-admin
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: kustomize-provisioner-admin
+    namespace: rukpak-system

--- a/manifests/provisioners/kustomize/resources/deployment.yaml
+++ b/manifests/provisioners/kustomize/resources/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: rukpak-system
+  name: kustomize-provisioner
+  labels:
+    app: kustomize-provisioner
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kustomize-provisioner
+  template:
+    metadata:
+      labels:
+        app: kustomize-provisioner
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: kustomize-provisioner-admin
+      containers:
+        - name: kube-rbac-proxy
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ "ALL" ]
+          image: quay.io/brancz/kube-rbac-proxy:v0.12.0
+          args:
+            - "--secure-listen-address=0.0.0.0:8443"
+            - "--upstream=http://127.0.0.1:8080/"
+            - "--logtostderr=true"
+            - "--v=1"
+            - "--client-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+            - "--tls-cert-file=/etc/pki/tls/tls.crt"
+            - "--tls-private-key-file=/etc/pki/tls/tls.key"
+          ports:
+            - containerPort: 8443
+              protocol: TCP
+              name: https
+          volumeMounts:
+            - name: certs
+              mountPath: /etc/pki/tls
+        - name: manager
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ "ALL" ]
+          image: quay.io/operator-framework/rukpak:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/kustomize"]
+          args:
+            - "--unpack-image=quay.io/operator-framework/rukpak:latest"
+            - "--base-upload-manager-url=https://$(CORE_SERVICE_NAME).$(CORE_SERVICE_NAMESPACE).svc"
+            - "--upload-storage-dir=/var/cache/bundles"
+            - "--http-bind-address=127.0.0.1:8080"
+            - "--http-external-address=https://$(KUSTOMIZE_PROVISIONER_SERVICE_NAME).$(KUSTOMIZE_PROVISIONER_SERVICE_NAMESPACE).svc"
+            - "--bundle-ca-file=/etc/pki/tls/ca.crt"
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: bundle-cache
+              mountPath: /var/cache/bundles
+            - name: certs
+              mountPath: /etc/pki/tls
+      volumes:
+        - name: bundle-cache
+          emptyDir: {}
+        - name: certs
+          secret:
+            secretName: kustomize-provisioner-cert
+            optional: false

--- a/manifests/provisioners/kustomize/resources/service.yaml
+++ b/manifests/provisioners/kustomize/resources/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: rukpak-system
+  name: kustomize-provisioner
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    app: kustomize-provisioner

--- a/manifests/provisioners/kustomize/resources/serviceaccount.yaml
+++ b/manifests/provisioners/kustomize/resources/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kustomize-provisioner-admin
+  namespace: rukpak-system

--- a/test/e2e/kustomize_provisioner_test.go
+++ b/test/e2e/kustomize_provisioner_test.go
@@ -1,0 +1,429 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	"github.com/operator-framework/rukpak/internal/provisioner/kustomize"
+)
+
+var _ = Describe("kustomize provisioner bundledeployment", func() {
+	When("a BundleDeployment targets a valid Bundle", func() {
+		var (
+			bd  *rukpakv1alpha1.BundleDeployment
+			ctx context.Context
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+
+			bd = &rukpakv1alpha1.BundleDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "kustomuze-",
+				},
+				Spec: rukpakv1alpha1.BundleDeploymentSpec{
+					ProvisionerClassName: kustomize.ProvisionerID,
+					Config:               runtime.RawExtension{Raw: []byte(`{"path": "dev"}`)},
+					Template: &rukpakv1alpha1.BundleTemplate{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app.kubernetes.io/name": "test-kustomize",
+							},
+						},
+						Spec: rukpakv1alpha1.BundleSpec{
+							ProvisionerClassName: kustomize.ProvisionerID,
+							Source: rukpakv1alpha1.BundleSource{
+								Type: rukpakv1alpha1.SourceTypeGit,
+								Git: &rukpakv1alpha1.GitSource{
+									Repository: "https://github.com/akihikokuroda/kustomize.git",
+									Directory:  "./manifests",
+									Ref: rukpakv1alpha1.GitRef{
+										Branch: "main",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			err := c.Create(ctx, bd)
+			Expect(err).To(BeNil())
+		})
+		AfterEach(func() {
+			By("deleting the testing resources")
+			Expect(c.Delete(ctx, bd)).To(BeNil())
+		})
+
+		It("should rollout the bundle contents successfully", func() {
+			By("eventually writing a successful installation state back to the bundledeployment status")
+			Eventually(func() (*metav1.Condition, error) {
+				if err := c.Get(ctx, client.ObjectKeyFromObject(bd), bd); err != nil {
+					return nil, err
+				}
+				if bd.Status.ActiveBundle == "" {
+					return nil, fmt.Errorf("waiting for bundle name to be populated")
+				}
+				return meta.FindStatusCondition(bd.Status.Conditions, rukpakv1alpha1.TypeInstalled), nil
+			}).Should(And(
+				Not(BeNil()),
+				WithTransform(func(c *metav1.Condition) string { return c.Type }, Equal(rukpakv1alpha1.TypeInstalled)),
+				WithTransform(func(c *metav1.Condition) metav1.ConditionStatus { return c.Status }, Equal(metav1.ConditionTrue)),
+				WithTransform(func(c *metav1.Condition) string { return c.Reason }, Equal(rukpakv1alpha1.ReasonInstallationSucceeded)),
+				WithTransform(func(c *metav1.Condition) string { return c.Message }, ContainSubstring("Instantiated bundle")),
+			))
+		})
+
+		When("the generated resource contains a pod manifest", func() {
+			It("should eventually result in an available pod resource", func() {
+				By("eventually install generated resource successfully")
+				pod := &corev1.Pod{}
+
+				Eventually(func() (*corev1.PodCondition, error) {
+					if err := c.Get(ctx, types.NamespacedName{Name: "dev-myapp-pod", Namespace: defaultSystemNamespace}, pod); err != nil {
+						return nil, err
+					}
+					for _, c := range pod.Status.Conditions {
+						if c.Type == corev1.PodReady {
+							return &c, nil
+						}
+					}
+					return nil, nil
+				}).Should(And(
+					Not(BeNil()),
+					WithTransform(func(c *corev1.PodCondition) corev1.PodConditionType { return c.Type }, Equal(corev1.PodReady)),
+					WithTransform(func(c *corev1.PodCondition) corev1.ConditionStatus { return c.Status }, Equal(corev1.ConditionTrue)),
+				))
+			})
+
+			It("should re-create a deployment resource when manually deleted", func() {
+				pod := &corev1.Pod{}
+
+				Eventually(func() error {
+					return c.Get(ctx, types.NamespacedName{Name: "dev-myapp-pod", Namespace: defaultSystemNamespace}, pod)
+				}).Should(Succeed())
+
+				By("storing the pod's original UID")
+				originalUID := pod.GetUID()
+
+				By("deleting the underlying pod and waiting for it to be re-created")
+				err := c.Delete(context.Background(), pod)
+				Expect(err).To(BeNil())
+
+				By("verifying the pod's UID has changed")
+				Eventually(func() (types.UID, error) {
+					err := c.Get(ctx, client.ObjectKeyFromObject(pod), pod)
+					return pod.GetUID(), err
+				}).ShouldNot(Equal(originalUID))
+			})
+		})
+	})
+	When("a BundleDeployment targets a valid Bundle specified path from repo root", func() {
+		var (
+			bd  *rukpakv1alpha1.BundleDeployment
+			ctx context.Context
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+
+			bd = &rukpakv1alpha1.BundleDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "kustomuze-",
+				},
+				Spec: rukpakv1alpha1.BundleDeploymentSpec{
+					ProvisionerClassName: kustomize.ProvisionerID,
+					Config:               runtime.RawExtension{Raw: []byte(`{"path": "manifests/dev"}`)},
+					Template: &rukpakv1alpha1.BundleTemplate{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app.kubernetes.io/name": "test-kustomize",
+							},
+						},
+						Spec: rukpakv1alpha1.BundleSpec{
+							ProvisionerClassName: kustomize.ProvisionerID,
+							Source: rukpakv1alpha1.BundleSource{
+								Type: rukpakv1alpha1.SourceTypeGit,
+								Git: &rukpakv1alpha1.GitSource{
+									Repository: "https://github.com/akihikokuroda/kustomize.git",
+									Ref: rukpakv1alpha1.GitRef{
+										Branch: "main",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			err := c.Create(ctx, bd)
+			Expect(err).To(BeNil())
+		})
+		AfterEach(func() {
+			By("deleting the testing resources")
+			Expect(c.Delete(ctx, bd)).To(BeNil())
+		})
+
+		It("should rollout the bundle contents successfully", func() {
+			By("eventually writing a successful installation state back to the bundledeployment status")
+			Eventually(func() (*metav1.Condition, error) {
+				if err := c.Get(ctx, client.ObjectKeyFromObject(bd), bd); err != nil {
+					return nil, err
+				}
+				if bd.Status.ActiveBundle == "" {
+					return nil, fmt.Errorf("waiting for bundle name to be populated")
+				}
+				return meta.FindStatusCondition(bd.Status.Conditions, rukpakv1alpha1.TypeInstalled), nil
+			}).Should(And(
+				Not(BeNil()),
+				WithTransform(func(c *metav1.Condition) string { return c.Type }, Equal(rukpakv1alpha1.TypeInstalled)),
+				WithTransform(func(c *metav1.Condition) metav1.ConditionStatus { return c.Status }, Equal(metav1.ConditionTrue)),
+				WithTransform(func(c *metav1.Condition) string { return c.Reason }, Equal(rukpakv1alpha1.ReasonInstallationSucceeded)),
+				WithTransform(func(c *metav1.Condition) string { return c.Message }, ContainSubstring("Instantiated bundle")),
+			))
+		})
+	})
+
+	When("a BundleDeployment targets a valid Bundle without specified path", func() {
+		var (
+			bd  *rukpakv1alpha1.BundleDeployment
+			ctx context.Context
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+
+			bd = &rukpakv1alpha1.BundleDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "kustomuze-",
+				},
+				Spec: rukpakv1alpha1.BundleDeploymentSpec{
+					ProvisionerClassName: kustomize.ProvisionerID,
+					Template: &rukpakv1alpha1.BundleTemplate{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app.kubernetes.io/name": "test-kustomize",
+							},
+						},
+						Spec: rukpakv1alpha1.BundleSpec{
+							ProvisionerClassName: kustomize.ProvisionerID,
+							Source: rukpakv1alpha1.BundleSource{
+								Type: rukpakv1alpha1.SourceTypeGit,
+								Git: &rukpakv1alpha1.GitSource{
+									Repository: "https://github.com/akihikokuroda/kustomize.git",
+									Directory:  "./manifests",
+									Ref: rukpakv1alpha1.GitRef{
+										Branch: "main",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			err := c.Create(ctx, bd)
+			Expect(err).To(BeNil())
+		})
+		AfterEach(func() {
+			By("deleting the testing resources")
+			Expect(c.Delete(ctx, bd)).To(BeNil())
+		})
+
+		It("should rollout the bundle contents successfully", func() {
+			By("eventually writing a successful installation state back to the bundledeployment status")
+			Eventually(func() (*metav1.Condition, error) {
+				if err := c.Get(ctx, client.ObjectKeyFromObject(bd), bd); err != nil {
+					return nil, err
+				}
+				if bd.Status.ActiveBundle == "" {
+					return nil, fmt.Errorf("waiting for bundle name to be populated")
+				}
+				return meta.FindStatusCondition(bd.Status.Conditions, rukpakv1alpha1.TypeInstalled), nil
+			}).Should(And(
+				Not(BeNil()),
+				WithTransform(func(c *metav1.Condition) string { return c.Type }, Equal(rukpakv1alpha1.TypeInstalled)),
+				WithTransform(func(c *metav1.Condition) metav1.ConditionStatus { return c.Status }, Equal(metav1.ConditionTrue)),
+				WithTransform(func(c *metav1.Condition) string { return c.Reason }, Equal(rukpakv1alpha1.ReasonInstallationSucceeded)),
+				WithTransform(func(c *metav1.Condition) string { return c.Message }, ContainSubstring("Instantiated bundle")),
+			))
+		})
+		It("should eventually result in an available pod resource", func() {
+			By("eventually install generated resource successfully")
+			pod := &corev1.Pod{}
+
+			Eventually(func() (*corev1.PodCondition, error) {
+				if err := c.Get(ctx, types.NamespacedName{Name: "cluster-a-dev-myapp-pod", Namespace: defaultSystemNamespace}, pod); err != nil {
+					return nil, err
+				}
+				for _, c := range pod.Status.Conditions {
+					if c.Type == corev1.PodReady {
+						return &c, nil
+					}
+				}
+				return nil, nil
+			}).Should(And(
+				Not(BeNil()),
+				WithTransform(func(c *corev1.PodCondition) corev1.PodConditionType { return c.Type }, Equal(corev1.PodReady)),
+				WithTransform(func(c *corev1.PodCondition) corev1.ConditionStatus { return c.Status }, Equal(corev1.ConditionTrue)),
+			))
+			Eventually(func() (*corev1.PodCondition, error) {
+				if err := c.Get(ctx, types.NamespacedName{Name: "cluster-a-prod-myapp-pod", Namespace: defaultSystemNamespace}, pod); err != nil {
+					return nil, err
+				}
+				for _, c := range pod.Status.Conditions {
+					if c.Type == corev1.PodReady {
+						return &c, nil
+					}
+				}
+				return nil, nil
+			}).Should(And(
+				Not(BeNil()),
+				WithTransform(func(c *corev1.PodCondition) corev1.PodConditionType { return c.Type }, Equal(corev1.PodReady)),
+				WithTransform(func(c *corev1.PodCondition) corev1.ConditionStatus { return c.Status }, Equal(corev1.ConditionTrue)),
+			))
+			Eventually(func() (*corev1.PodCondition, error) {
+				if err := c.Get(ctx, types.NamespacedName{Name: "cluster-a-stag-myapp-pod", Namespace: defaultSystemNamespace}, pod); err != nil {
+					return nil, err
+				}
+				for _, c := range pod.Status.Conditions {
+					if c.Type == corev1.PodReady {
+						return &c, nil
+					}
+				}
+				return nil, nil
+			}).Should(And(
+				Not(BeNil()),
+				WithTransform(func(c *corev1.PodCondition) corev1.PodConditionType { return c.Type }, Equal(corev1.PodReady)),
+				WithTransform(func(c *corev1.PodCondition) corev1.ConditionStatus { return c.Status }, Equal(corev1.ConditionTrue)),
+			))
+		})
+	})
+
+	When("a BundleDeployment targets an invalid Bundle", func() {
+		var (
+			bd  *rukpakv1alpha1.BundleDeployment
+			ctx context.Context
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+
+			bd = &rukpakv1alpha1.BundleDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "kustomuze-",
+				},
+				Spec: rukpakv1alpha1.BundleDeploymentSpec{
+					ProvisionerClassName: kustomize.ProvisionerID,
+					Config:               runtime.RawExtension{Raw: []byte(`{"path": "invalid"}`)},
+					Template: &rukpakv1alpha1.BundleTemplate{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app.kubernetes.io/name": "test-kustomize",
+							},
+						},
+						Spec: rukpakv1alpha1.BundleSpec{
+							ProvisionerClassName: kustomize.ProvisionerID,
+							Source: rukpakv1alpha1.BundleSource{
+								Type: rukpakv1alpha1.SourceTypeGit,
+								Git: &rukpakv1alpha1.GitSource{
+									Repository: "https://github.com/akihikokuroda/kustomize.git",
+									Directory:  "./invalid",
+									Ref: rukpakv1alpha1.GitRef{
+										Branch: "main",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			err := c.Create(ctx, bd)
+			Expect(err).To(BeNil())
+		})
+		AfterEach(func() {
+			By("deleting the testing resources")
+			Expect(c.Delete(ctx, bd)).To(BeNil())
+		})
+
+		It("should fail kustomizing resources", func() {
+			By("eventually writing a bundle load fail state back to the bundledeployment status")
+			Eventually(func() (*metav1.Condition, error) {
+				if err := c.Get(ctx, client.ObjectKeyFromObject(bd), bd); err != nil {
+					return nil, err
+				}
+				return meta.FindStatusCondition(bd.Status.Conditions, rukpakv1alpha1.TypeHasValidBundle), nil
+			}).Should(And(
+				Not(BeNil()),
+				WithTransform(func(c *metav1.Condition) string { return c.Type }, Equal(rukpakv1alpha1.TypeHasValidBundle)),
+				WithTransform(func(c *metav1.Condition) metav1.ConditionStatus { return c.Status }, Equal(metav1.ConditionFalse)),
+				WithTransform(func(c *metav1.Condition) string { return c.Reason }, Equal(rukpakv1alpha1.ReasonUnpackFailed)),
+				WithTransform(func(c *metav1.Condition) string { return c.Message }, ContainSubstring("Failed to unpack")),
+			))
+		})
+	})
+	When("a kuztomize path is invalid", func() {
+		var (
+			bd  *rukpakv1alpha1.BundleDeployment
+			ctx context.Context
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+
+			bd = &rukpakv1alpha1.BundleDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "kustomuze-",
+				},
+				Spec: rukpakv1alpha1.BundleDeploymentSpec{
+					ProvisionerClassName: kustomize.ProvisionerID,
+					Config:               runtime.RawExtension{Raw: []byte(`{"path": "invalid"}`)},
+					Template: &rukpakv1alpha1.BundleTemplate{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"app.kubernetes.io/name": "test-kustomize",
+							},
+						},
+						Spec: rukpakv1alpha1.BundleSpec{
+							ProvisionerClassName: kustomize.ProvisionerID,
+							Source: rukpakv1alpha1.BundleSource{
+								Type: rukpakv1alpha1.SourceTypeGit,
+								Git: &rukpakv1alpha1.GitSource{
+									Repository: "https://github.com/akihikokuroda/kustomize.git",
+									Directory:  "./manifests",
+									Ref: rukpakv1alpha1.GitRef{
+										Branch: "main",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			err := c.Create(ctx, bd)
+			Expect(err).To(BeNil())
+		})
+		AfterEach(func() {
+			By("deleting the testing resources")
+			Expect(c.Delete(ctx, bd)).To(BeNil())
+		})
+
+		It("should fail kustomizing resources", func() {
+			By("eventually writing a bundle load fail state back to the bundledeployment status")
+			Eventually(func() (*metav1.Condition, error) {
+				if err := c.Get(ctx, client.ObjectKeyFromObject(bd), bd); err != nil {
+					return nil, err
+				}
+				return meta.FindStatusCondition(bd.Status.Conditions, rukpakv1alpha1.TypeHasValidBundle), nil
+			}).Should(And(
+				Not(BeNil()),
+				WithTransform(func(c *metav1.Condition) string { return c.Type }, Equal(rukpakv1alpha1.TypeHasValidBundle)),
+				WithTransform(func(c *metav1.Condition) metav1.ConditionStatus { return c.Status }, Equal(metav1.ConditionFalse)),
+				WithTransform(func(c *metav1.Condition) string { return c.Reason }, Equal(rukpakv1alpha1.ReasonBundleLoadFailed)),
+				WithTransform(func(c *metav1.Condition) string { return c.Message }, ContainSubstring("kustomize error: must build at directory: not a valid directory")),
+			))
+		})
+	})
+})


### PR DESCRIPTION
Signed-off-by: akihikokuroda akuroda@us.ibm.com

Add kustomize provisioner

It supports following bundledeployment:
```
apiVersion: core.rukpak.io/v1alpha1
kind: BundleDeployment
metadata:
  name: my-kustomize
spec:
  provisionerClassName: core-rukpak-io-kustomize
  config:
    path: dev
  template:
    metadata:
      labels:
        app: my-kustomize
    spec:
      provisionerClassName: core-rukpak-io-kustomize
      source:
        git:
          ref:
            branch: main
          repository: https://github.com/akihikokuroda/kustomize
          directory: ./manifests
        type: git

```

Closes #572 