### PR TITLE
test(e2e): add ability to configure the image registry for test images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,9 @@ test-unit: setup-envtest ## Run the unit tests
 	eval $$($(SETUP_ENVTEST) use -p env $(ENVTEST_VERSION)) && go test -tags $(GO_BUILD_TAGS) -count=1 -short $(UNIT_TEST_DIRS)
 
 FOCUS := $(if $(TEST),-v -focus "$(TEST)")
+E2E_FLAGS ?= ""
 test-e2e: ginkgo ## Run the e2e tests
-	$(GINKGO) --tags $(GO_BUILD_TAGS) -trace -progress $(FOCUS) test/e2e
+	$(GINKGO) --tags $(GO_BUILD_TAGS) $(E2E_FLAGS) -trace -progress $(FOCUS) test/e2e
 
 e2e: KIND_CLUSTER_NAME=rukpak-e2e
 e2e: rukpakctl run image-registry kind-load-bundles registry-load-bundles test-e2e kind-cluster-cleanup ## Run e2e tests against an ephemeral kind cluster

--- a/test/e2e/image_repo.go
+++ b/test/e2e/image_repo.go
@@ -1,0 +1,5 @@
+package e2e
+
+// ImageRepo is meant to be set via -ldflags during execution of this code
+// where it will then be used to configure the testing suite.
+var ImageRepo = "testdata/bundles"

--- a/test/e2e/plain_provisioner_test.go
+++ b/test/e2e/plain_provisioner_test.go
@@ -67,7 +67,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
-							Ref: "testdata/bundles/plain-v0:valid",
+							Ref: fmt.Sprintf("%v/%v", ImageRepo, "plain-v0:valid"),
 						},
 					},
 				},
@@ -107,7 +107,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
-							Ref: "testdata/bundles/plain-v0:valid",
+							Ref: fmt.Sprintf("%v/%v", ImageRepo, "plain-v0:valid"),
 						},
 					},
 				},
@@ -286,7 +286,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
-							Ref: "testdata/bundles/plain-v0:non-existent-tag",
+							Ref: fmt.Sprintf("%v/%v", ImageRepo, "plain-v0:non-existent-tag"),
 						},
 					},
 				},
@@ -360,7 +360,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
-							Ref: "testdata/bundles/plain-v0:empty",
+							Ref: fmt.Sprintf("%v/%v", ImageRepo, "plain-v0:empty"),
 						},
 					},
 				},
@@ -409,7 +409,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
-							Ref: "testdata/bundles/plain-v0:no-manifests",
+							Ref: fmt.Sprintf("%v/%v", ImageRepo, "plain-v0:no-manifests"),
 						},
 					},
 				},
@@ -1136,7 +1136,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
-							Ref: "testdata/bundles/plain-v0:subdir",
+							Ref: fmt.Sprintf("%v/%v", ImageRepo, "plain-v0:subdir"),
 						},
 					},
 				},
@@ -1346,7 +1346,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
-									Ref: "testdata/bundles/plain-v0:valid",
+									Ref: fmt.Sprintf("%v/%v", ImageRepo, "plain-v0:valid"),
 								},
 							},
 						},
@@ -1582,7 +1582,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
-									Ref: "testdata/bundles/plain-v0:valid",
+									Ref: fmt.Sprintf("%v/%v", ImageRepo, "plain-v0:valid"),
 								},
 							},
 						},
@@ -1641,7 +1641,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
-									Ref: "testdata/bundles/plain-v0:invalid-missing-crds",
+									Ref: fmt.Sprintf("%v/%v", ImageRepo, "plain-v0:invalid-missing-crds"),
 								},
 							},
 						},
@@ -1708,7 +1708,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
-									Ref: "testdata/bundles/plain-v0:subdir",
+									Ref: fmt.Sprintf("%v/%v", ImageRepo, "plain-v0:subdir"),
 								},
 							},
 						},
@@ -1772,7 +1772,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
-									Ref: "testdata/bundles/plain-v0:dependent",
+									Ref: fmt.Sprintf("%v/%v", ImageRepo, "plain-v0:dependent"),
 								},
 							},
 						},
@@ -1829,7 +1829,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 								Source: rukpakv1alpha1.BundleSource{
 									Type: rukpakv1alpha1.SourceTypeImage,
 									Image: &rukpakv1alpha1.ImageSource{
-										Ref: "testdata/bundles/plain-v0:provides",
+										Ref: fmt.Sprintf("%v/%v", ImageRepo, "plain-v0:provides"),
 									},
 								},
 							},
@@ -1890,7 +1890,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
-									Ref: "testdata/bundles/plain-v0:invalid-crds-and-crs",
+									Ref: fmt.Sprintf("%v/%v", ImageRepo, "plain-v0:invalid-crds-and-crs"),
 								},
 							},
 						},
@@ -1940,7 +1940,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
-							Ref: "testdata/bundles/plain-v0:valid",
+							Ref: fmt.Sprintf("%v/%v", ImageRepo, "plain-v0:valid"),
 						},
 					},
 				},
@@ -2022,7 +2022,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
-									Ref: "testdata/bundles/plain-v0:valid",
+									Ref: fmt.Sprintf("%v/%v", ImageRepo, "plain-v0:valid"),
 								},
 							},
 						},
@@ -2116,7 +2116,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
-									Ref: "testdata/bundles/plain-v0:valid",
+									Ref: fmt.Sprintf("%v/%v", ImageRepo, "plain-v0:valid"),
 								},
 							},
 						},

--- a/test/e2e/registry_provisioner_test.go
+++ b/test/e2e/registry_provisioner_test.go
@@ -41,7 +41,7 @@ var _ = Describe("registry provisioner bundle", func() {
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
-									Ref: "testdata/bundles/registry:valid",
+									Ref: fmt.Sprintf("%v/%v", ImageRepo, "registry:valid"),
 								},
 							},
 						},
@@ -100,7 +100,7 @@ var _ = Describe("registry provisioner bundle", func() {
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
-									Ref: "testdata/bundles/registry:invalid",
+									Ref: fmt.Sprintf("%v/%v", ImageRepo, "registry:invalid"),
 								},
 							},
 						},


### PR DESCRIPTION
Adding some small changes to enable testing to be a bit more configurable. This will allow downstream consumers of Rukpak to specify what image registry that their test images are served from. 