### PR TITLE
add resources/requests to containers

### DIFF
--- a/manifests/apis/webhooks/resources/deployment.yaml
+++ b/manifests/apis/webhooks/resources/deployment.yaml
@@ -38,6 +38,10 @@ spec:
           - mountPath: /tmp/k8s-webhook-server/serving-certs
             name: cert
             readOnly: true
+          resources:
+            requests:
+              cpu: 1m
+              memory: 15Mi
       volumes:
         - name: cert
           secret:

--- a/manifests/core/resources/deployment.yaml
+++ b/manifests/core/resources/deployment.yaml
@@ -44,6 +44,10 @@ spec:
           volumeMounts:
             - name: certs
               mountPath: /etc/pki/tls
+          resources:
+            requests:
+              cpu: 1m
+              memory: 15Mi
         - name: manager
           securityContext:
             allowPrivilegeEscalation: false
@@ -69,6 +73,10 @@ spec:
               mountPath: /var/cache/uploads
             - name: certs
               mountPath: /etc/pki/tls
+          resources:
+            requests:
+              cpu: 10m
+              memory: 160Mi
       volumes:
         - name: bundle-cache
           emptyDir: {}

--- a/manifests/crdvalidator/05_deployment.yaml
+++ b/manifests/crdvalidator/05_deployment.yaml
@@ -21,6 +21,10 @@ spec:
           volumeMounts:
             - name: tls
               mountPath: "/etc/admission-webhook/tls"
+          resources:
+            requests:
+              cpu: 1m
+              memory: 15Mi
       volumes:
         - name: tls
           secret:

--- a/manifests/provisioners/helm/resources/deployment.yaml
+++ b/manifests/provisioners/helm/resources/deployment.yaml
@@ -44,6 +44,10 @@ spec:
           volumeMounts:
             - name: certs
               mountPath: /etc/pki/tls
+          resources:
+            requests:
+              cpu: 1m
+              memory: 15Mi
         - name: manager
           securityContext:
             allowPrivilegeEscalation: false
@@ -66,6 +70,10 @@ spec:
               mountPath: /var/cache/bundles
             - name: certs
               mountPath: /etc/pki/tls
+          resources:
+            requests:
+              cpu: 10m
+              memory: 160Mi
       volumes:
         - name: bundle-cache
           emptyDir: {}


### PR DESCRIPTION
Signed-off-by: akihikokuroda <akuroda@us.ibm.com>

Closes #571

All the patches for the resources/requests are in the manifests/kustomize.yaml file.  The `vars` of the kustomize seems better way but it is [deprecated](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/vars/).