### PR TITLE
.github/workflows: Get Go version from root go.mod file

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
-        go-version: '~1.19'
+        go-version-file: "go.mod"
     - name: Run e2e tests
       run: |
         make e2e

--- a/.github/workflows/go-apidiff.yaml
+++ b/.github/workflows/go-apidiff.yaml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
-        go-version: '~1.19'
+        go-version-file: "go.mod"
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/release-e2e.yaml
+++ b/.github/workflows/release-e2e.yaml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
-        go-version: '~1.19'
+        go-version-file: "go.mod"
 
     - name: Download kubectl
       run: |
@@ -31,7 +31,6 @@ jobs:
       run: |
         kubectl apply -f https://github.com/operator-framework/rukpak/releases/download/${{ github.event.release.tag_name }}/rukpak.yaml
         make wait
-
 
     - name: Load testdata bundle container images into kind
       run: make kind-load-bundles KIND=hack/tools/bin/kind

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,9 +22,9 @@ jobs:
         fetch-depth: 0
 
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: ~1.19
+        go-version-file: "go.mod"
 
     - name: Docker Login
       if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: '~1.19'
+          go-version-file: "go.mod"
       - name: Run verification checks
         run: make verify
   lint:
@@ -23,9 +23,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: '~1.19'
+          go-version-file: "go.mod"
 
       - name: Cache build and module paths
         uses: actions/cache@v3

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: '~1.19'
+          go-version-file: "go.mod"
       - run: make test-unit


### PR DESCRIPTION
Use the actions/setup-go v3 major version, which has support for configuring Go based on the version specified in the root go.mod file. This reduces the amount of changes needed to bump Go versions over time.

Signed-off-by: timflannagan <timflannagan@gmail.com>