### PR TITLE
Set bundle deployment controller name correctly

### DIFF
--- a/internal/provisioner/bundledeployment/bundledeployment.go
+++ b/internal/provisioner/bundledeployment/bundledeployment.go
@@ -102,9 +102,10 @@ func SetupProvisioner(mgr manager.Manager, opts ...Option) error {
 		return fmt.Errorf("invalid configuration: %v", err)
 	}
 
-	controllerName := fmt.Sprintf("controller.bundle.%s", bd.provisionerID)
+	controllerName := fmt.Sprintf("controller.bundledeployment.%s", bd.provisionerID)
 	l := mgr.GetLogger().WithName(controllerName)
 	controller, err := ctrl.NewControllerManagedBy(mgr).
+		Named(controllerName).
 		For(&rukpakv1alpha1.BundleDeployment{}, builder.WithPredicates(
 			util.BundleDeploymentProvisionerFilter(bd.provisionerID)),
 		).


### PR DESCRIPTION
This ensures that metrics produced by controller runtime use a controller name that includes the provisioner ID, which is important in cases where there are multiple bundle deployment controllers running in the same manager pod. Without this, controller-runtime chooses `bundledeployment` for the controller name (which is derived from the `For` type).