### PR TITLE
add Notes.txt contents in condition message

### DIFF
--- a/docs/provisioners/helm.md
+++ b/docs/provisioners/helm.md
@@ -92,6 +92,8 @@ NAME      ACTIVE BUNDLE        INSTALL STATE           AGE
 my-ahoy   my-ahoy-5764594dc8   InstallationSucceeded   48s
 ```
 
+The contents of [templates/NOTES.txt](https://helm.sh/docs/chart_template_guide/notes_files/#helm) is in the `message` of the `Installed` condition in the BundleDeployment.
+
 > Note: Creation of more than one BundleDeployment from the same Bundle will likely result in an error.
 
 ## Quick Start

--- a/internal/provisioner/bundledeployment/bundledeployment.go
+++ b/internal/provisioner/bundledeployment/bundledeployment.go
@@ -401,7 +401,7 @@ func (p *bundledeploymentProvisioner) reconcile(ctx context.Context, bd *rukpakv
 		Type:    rukpakv1alpha1.TypeInstalled,
 		Status:  metav1.ConditionTrue,
 		Reason:  rukpakv1alpha1.ReasonInstallationSucceeded,
-		Message: fmt.Sprintf("Instantiated bundle %s successfully", bundle.GetName()),
+		Message: fmt.Sprintf("Instantiated bundle %s successfully\nNotes:  %s", bundle.GetName(), rel.Info.Notes),
 	})
 	bd.Status.ActiveBundle = bundle.GetName()
 


### PR DESCRIPTION
Signed-off-by: akihikokuroda <akuroda@us.ibm.com>

Closes #499 

The contents of `templates/NOTES.txt` is added to the `message` in the Installed condition. 