### PR TITLE
style: introduce gosec linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,6 +10,7 @@ linters:
   - errorlint
   - gofmt
   - goimports
+  - gosec
   - importas
   - misspell
   - nestif
@@ -39,7 +40,6 @@ linters-settings:
       alias: rukpakv1alpha1
   goimports:
     local-prefixes: github.com/operator-framework/rukpak
-
 
 output:
   format: tab

--- a/internal/provisioner/bundledeployment/bundledeployment.go
+++ b/internal/provisioner/bundledeployment/bundledeployment.go
@@ -418,11 +418,11 @@ func (p *bundledeploymentProvisioner) reconcileOldBundles(ctx context.Context, c
 	var (
 		errors []error
 	)
-	for _, bundle := range allBundles.Items {
-		if bundle.GetName() == currBundle.GetName() {
+	for i := range allBundles.Items {
+		if allBundles.Items[i].GetName() == currBundle.GetName() {
 			continue
 		}
-		if err := p.cl.Delete(ctx, &bundle); err != nil {
+		if err := p.cl.Delete(ctx, &allBundles.Items[i]); err != nil {
 			errors = append(errors, err)
 			continue
 		}

--- a/internal/source/git.go
+++ b/internal/source/git.go
@@ -153,7 +153,7 @@ func (r *Git) configAuth(ctx context.Context, bundle *rukpakv1alpha1.Bundle) (tr
 			User:   "git",
 			Signer: signer,
 			HostKeyCallbackHelper: sshgit.HostKeyCallbackHelper{
-				HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+				HostKeyCallback: ssh.InsecureIgnoreHostKey(), // nolint:gosec
 			},
 		}
 	} else if host != nil {

--- a/internal/source/http.go
+++ b/internal/source/http.go
@@ -46,7 +46,7 @@ func (b *HTTP) Unpack(ctx context.Context, bundle *rukpakv1alpha1.Bundle) (*Resu
 	httpClient := http.Client{Timeout: 10 * time.Second}
 	if bundle.Spec.Source.HTTP.Auth.InsecureSkipVerify {
 		tr := http.DefaultTransport.(*http.Transport).Clone()
-		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // nolint:gosec
 		httpClient.Transport = tr
 	}
 

--- a/internal/source/unpacker.go
+++ b/internal/source/unpacker.go
@@ -109,7 +109,9 @@ func NewDefaultUnpacker(mgr ctrl.Manager, namespace, unpackImage string, baseUpl
 	}
 	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
 	if httpTransport.TLSClientConfig == nil {
-		httpTransport.TLSClientConfig = &tls.Config{}
+		httpTransport.TLSClientConfig = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
 	}
 	httpTransport.TLSClientConfig.RootCAs = rootCAs
 	return NewUnpacker(map[rukpakv1alpha1.SourceType]Unpacker{

--- a/internal/storage/http.go
+++ b/internal/storage/http.go
@@ -27,7 +27,9 @@ func WithInsecureSkipVerify(v bool) HTTPOption {
 	return func(s *HTTP) {
 		tr := s.client.Transport.(*http.Transport)
 		if tr.TLSClientConfig == nil {
-			tr.TLSClientConfig = &tls.Config{}
+			tr.TLSClientConfig = &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			}
 		}
 		tr.TLSClientConfig.InsecureSkipVerify = v
 	}
@@ -37,7 +39,9 @@ func WithRootCAs(rootCAs *x509.CertPool) HTTPOption {
 	return func(s *HTTP) {
 		tr := s.client.Transport.(*http.Transport)
 		if tr.TLSClientConfig == nil {
-			tr.TLSClientConfig = &tls.Config{}
+			tr.TLSClientConfig = &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			}
 		}
 		tr.TLSClientConfig.RootCAs = rootCAs
 	}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -239,11 +239,11 @@ func GetBundlesForBundleDeploymentSelector(ctx context.Context, c client.Client,
 // match the desired Bundle template that's specified in a BundleDeployment object. If a match
 // is found, that Bundle object is returned, so callers are responsible for nil checking the result.
 func CheckExistingBundlesMatchesTemplate(existingBundles *rukpakv1alpha1.BundleList, desiredBundleTemplate *rukpakv1alpha1.BundleTemplate) *rukpakv1alpha1.Bundle {
-	for _, bundle := range existingBundles.Items {
-		if !CheckDesiredBundleTemplate(&bundle, desiredBundleTemplate) {
+	for i := range existingBundles.Items {
+		if !CheckDesiredBundleTemplate(&existingBundles.Items[i], desiredBundleTemplate) {
 			continue
 		}
-		return bundle.DeepCopy()
+		return existingBundles.Items[i].DeepCopy()
 	}
 	return nil
 }

--- a/test/e2e/rukpakctl_test.go
+++ b/test/e2e/rukpakctl_test.go
@@ -210,7 +210,7 @@ var _ = Describe("rukpakctl content subcommand", func() {
 					return bundle.Status.Phase, nil
 				}).Should(Equal(rukpakv1alpha1.PhaseUnpacked))
 			})
-			out, err := exec.Command("sh", "-c", rukpakctlcmd+"content "+bundle.ObjectMeta.Name).Output()
+			out, err := exec.Command("sh", "-c", rukpakctlcmd+"content "+bundle.ObjectMeta.Name).Output() // nolint:gosec
 			Expect(err).To(BeNil())
 			output = string(out)
 		})
@@ -286,7 +286,7 @@ var _ = Describe("rukpakctl content subcommand", func() {
 					WithTransform(func(c *metav1.Condition) metav1.ConditionStatus { return c.Status }, Equal(metav1.ConditionFalse)),
 					WithTransform(func(c *metav1.Condition) string { return c.Reason }, Equal(rukpakv1alpha1.ReasonUnpackFailed)),
 				))
-				out, err := exec.Command("sh", "-c", rukpakctlcmd+"content "+bundlename).CombinedOutput()
+				out, err := exec.Command("sh", "-c", rukpakctlcmd+"content "+bundlename).CombinedOutput() // nolint: gosec
 				Expect(err).NotTo(BeNil())
 				output = string(out)
 			})


### PR DESCRIPTION
Signed-off-by: Tony Jin <kavinjsir@gmail.com>

## Description
Introduce `gosec` lint checker

- [x] import `gosec` in `golangci-lint` config
- [x] made corresponding style changes based on lint check

## Open Questions
1. Some changes are made based on gosec report, are these updates good OR any suggestions?
2. Wondering if is necessary to exclude some in the configuration?

## Motivation
Resolve: https://github.com/operator-framework/rukpak/issues/533