### PR TITLE
fix: fill message in bundle status

### DIFF
--- a/internal/source/common.go
+++ b/internal/source/common.go
@@ -1,0 +1,9 @@
+package source
+
+import (
+	"fmt"
+)
+
+func generateMessage(bundleName string) string {
+	return fmt.Sprintf("Successfully unpacked the %s Bundle", bundleName)
+}

--- a/internal/source/git.go
+++ b/internal/source/git.go
@@ -123,7 +123,9 @@ func (r *Git) Unpack(ctx context.Context, bundle *rukpakv1alpha1.Bundle) (*Resul
 		Git:  resolvedGit,
 	}
 
-	return &Result{Bundle: bundleFS, ResolvedSource: resolvedSource, State: StateUnpacked}, nil
+	message := generateMessage("git")
+
+	return &Result{Bundle: bundleFS, ResolvedSource: resolvedSource, State: StateUnpacked, Message: message}, nil
 }
 
 func (r *Git) configAuth(ctx context.Context, bundle *rukpakv1alpha1.Bundle) (transport.AuthMethod, error) {

--- a/internal/source/http.go
+++ b/internal/source/http.go
@@ -67,7 +67,10 @@ func (b *HTTP) Unpack(ctx context.Context, bundle *rukpakv1alpha1.Bundle) (*Resu
 	if err != nil {
 		return nil, fmt.Errorf("error creating FS: %s", err)
 	}
-	return &Result{Bundle: fs, ResolvedSource: bundle.Spec.Source.DeepCopy(), State: StateUnpacked}, nil
+
+	message := generateMessage("http")
+
+	return &Result{Bundle: fs, ResolvedSource: bundle.Spec.Source.DeepCopy(), State: StateUnpacked, Message: message}, nil
 }
 
 // getCredentials reads credentials from the secret specified in the bundle

--- a/internal/source/image.go
+++ b/internal/source/image.go
@@ -208,7 +208,9 @@ func (i *Image) succeededPodResult(ctx context.Context, pod *corev1.Pod) (*Resul
 		Image: &rukpakv1alpha1.ImageSource{Ref: digest},
 	}
 
-	return &Result{Bundle: bundleFS, ResolvedSource: resolvedSource, State: StateUnpacked}, nil
+	message := generateMessage("image")
+
+	return &Result{Bundle: bundleFS, ResolvedSource: resolvedSource, State: StateUnpacked, Message: message}, nil
 }
 
 func (i *Image) getBundleContents(ctx context.Context, pod *corev1.Pod) (fs.FS, error) {

--- a/internal/source/local.go
+++ b/internal/source/local.go
@@ -74,5 +74,7 @@ func (o *Local) Unpack(ctx context.Context, bundle *rukpakv1alpha1.Bundle) (*Res
 		Local: bundle.Spec.Source.Local.DeepCopy(),
 	}
 
-	return &Result{Bundle: bundleFS, ResolvedSource: resolvedSource, State: StateUnpacked}, nil
+	message := generateMessage("local")
+
+	return &Result{Bundle: bundleFS, ResolvedSource: resolvedSource, State: StateUnpacked, Message: message}, nil
 }

--- a/internal/source/upload.go
+++ b/internal/source/upload.go
@@ -52,5 +52,8 @@ func (b *Upload) Unpack(ctx context.Context, bundle *rukpakv1alpha1.Bundle) (*Re
 	if err != nil {
 		return nil, fmt.Errorf("untar bundle contents from response: %v", err)
 	}
-	return &Result{Bundle: bundleFS, ResolvedSource: bundle.Spec.Source.DeepCopy(), State: StateUnpacked}, nil
+
+	message := generateMessage("upload")
+
+	return &Result{Bundle: bundleFS, ResolvedSource: bundle.Spec.Source.DeepCopy(), State: StateUnpacked, Message: message}, nil
 }


### PR DESCRIPTION
Signed-off-by: Tony Jin <kavinjsir@gmail.com>

### Description

Fill the `message` field in the `bundle` status condition for the UnpackSuccessful reason.

<img width="474" alt="Screen Shot 2022-11-23 at 4 23 18 PM" src="https://user-images.githubusercontent.com/18136486/203648439-48935480-b1bb-4f77-b862-a2f6f935550a.png">

### Motivation
Resolve: https://github.com/operator-framework/rukpak/issues/529
