### PR TITLE
Remote debug make target

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,35 @@ make run
 
 > Note: RukPak may take some time to become fully operational while its controllers and webhooks are spinning up during installation. As a result, please allow a few moments before creating Bundles/BundleDeployments if you are noticing unexpected failures.
 
+### Debugging
+
+The following make target is also available to developers that wish to debug the container remotely through `dlv`. Once completed, a remote debugging session may be attached through any preferred IDE on `localhost:40000` :
+
+```bash
+make debug
+```
+
+As an example, the following `launch.json` file may be used to connect to the debugging session with vscode:
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Remote Debugging",
+      "type": "go",
+      "request": "attach",
+      "mode": "remote",
+      "remotePath": "",
+      "port":40000,
+      "host":"127.0.0.1",
+      "showLog": true,
+      "trace": "log",
+      "logOutput": "rpc"
+    }
+  ]
+}
+```
+
 There are currently no other supported ways of installing RukPak, although there are plans to add support for other
 popular packaging formats such as a Helm chart or an OLM bundle.
 

--- a/test/tools/remotedebug/kind-config.yaml
+++ b/test/tools/remotedebug/kind-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 31111
+    hostPort: 40000
+    listenAddress: "0.0.0.0" # Optional, defaults to "0.0.0.0"
+    protocol: tcp # Optional, defaults to tcp

--- a/test/tools/remotedebug/kustomization.yaml
+++ b/test/tools/remotedebug/kustomization.yaml
@@ -1,0 +1,14 @@
+resources:
+  - ../../../manifests/
+  - ./resources/service.yaml
+
+patchesJson6902:
+- target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: core
+  path: patch/remote_debug_command.yaml
+
+patchesStrategicMerge:
+  - patch/install_dlv_init.yaml

--- a/test/tools/remotedebug/patch/install_dlv_init.yaml
+++ b/test/tools/remotedebug/patch/install_dlv_init.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: rukpak-system
+  name: core
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: false
+      volumes:
+      - name: gobindir
+        emptyDir: {}
+      initContainers:
+        - name: install-dlv
+          env:
+          - name: CGO_ENABLED
+            value: "0"
+          image: golang:1.17
+          command:
+          - go
+          args:
+          - install
+          - -ldflags
+          - "-s -w -extldflags '-static'"
+          - github.com/go-delve/delve/cmd/dlv@latest
+          volumeMounts:
+          - name: gobindir
+            mountPath: /go/bin/
+      containers:
+        - name: kube-rbac-proxy
+        - name: manager
+          volumeMounts:
+          - name: gobindir
+            mountPath: /go/bin/

--- a/test/tools/remotedebug/patch/remote_debug_command.yaml
+++ b/test/tools/remotedebug/patch/remote_debug_command.yaml
@@ -1,0 +1,33 @@
+# Move the original command to the beginning of the args array
+- op: copy
+  from: /spec/template/spec/containers/1/command/0
+  path: /spec/template/spec/containers/1/args/0
+# Set the command to /dlv
+- op: add
+  path: /spec/template/spec/containers/1/command
+  value: ["/go/bin/dlv"]
+# Prepend the args array with the following dlv args
+- op: add
+  path: /spec/template/spec/containers/1/args/0
+  value: "--listen=:40000"
+- op: add
+  path: /spec/template/spec/containers/1/args/1
+  value: "--continue"
+- op: add
+  path: /spec/template/spec/containers/1/args/2
+  value: "--headless=true"
+- op: add
+  path: /spec/template/spec/containers/1/args/3
+  value: "--api-version=2"
+- op: add
+  path: /spec/template/spec/containers/1/args/4
+  value: "--accept-multiclient"
+- op: add
+  path: /spec/template/spec/containers/1/args/5
+  value: "--log"
+- op: add
+  path: /spec/template/spec/containers/1/args/6
+  value: "exec"
+- op: add
+  path: /spec/template/spec/containers/1/args/7
+  value: "--"

--- a/test/tools/remotedebug/resources/service.yaml
+++ b/test/tools/remotedebug/resources/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: core-remote-debug
+  namespace: rukpak-system
+spec:
+  type: NodePort
+  ports:
+  - port: 40000
+    targetPort: 40000
+    nodePort: 31111
+    protocol: TCP
+  selector:
+    app: core


### PR DESCRIPTION
Adds `debug` make target to rukpak. The `debug` target is essentially the same as the `run` target except that, once finished, it exposes a local port to allow for remote debugging in the rukpak `core` container. This is done with the following:
* kind config to establish nodePort mapping
* deployment patches which:
  * add an initContainer to install `dlv`
  * prepend the `core` container command and args to run with dlv
* a service to link the `dlv` listener to the exposed nodePort

README is also updated to document the `debug` target and provides example launch config for vscode debugging.