### PR TITLE
Fix e2e: Force localhost for some containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,32 +174,32 @@ build-container: $(LINUX_BINARIES) ## Builds provisioner container image locally
 	$(CONTAINER_RUNTIME) build -f Dockerfile -t $(IMAGE) $(BIN_DIR)/linux
 
 kind-load-bundles: kind ## Load the e2e testdata container images into a kind cluster
-	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/valid -t testdata/bundles/plain-v0:valid
-	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/dependent -t testdata/bundles/plain-v0:dependent
-	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/provides -t testdata/bundles/plain-v0:provides
-	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/empty -t testdata/bundles/plain-v0:empty
-	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/no-manifests -t testdata/bundles/plain-v0:no-manifests
-	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/invalid-missing-crds -t testdata/bundles/plain-v0:invalid-missing-crds
-	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/invalid-crds-and-crs -t testdata/bundles/plain-v0:invalid-crds-and-crs
-	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/subdir -t testdata/bundles/plain-v0:subdir
-	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/registry/valid -t testdata/bundles/registry:valid
-	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/registry/invalid -t testdata/bundles/registry:invalid
-	$(KIND) load docker-image testdata/bundles/plain-v0:valid --name $(KIND_CLUSTER_NAME)
-	$(KIND) load docker-image testdata/bundles/plain-v0:dependent --name $(KIND_CLUSTER_NAME)
-	$(KIND) load docker-image testdata/bundles/plain-v0:provides --name $(KIND_CLUSTER_NAME)
-	$(KIND) load docker-image testdata/bundles/plain-v0:empty --name $(KIND_CLUSTER_NAME)
-	$(KIND) load docker-image testdata/bundles/plain-v0:no-manifests --name $(KIND_CLUSTER_NAME)
-	$(KIND) load docker-image testdata/bundles/plain-v0:invalid-missing-crds --name $(KIND_CLUSTER_NAME)
-	$(KIND) load docker-image testdata/bundles/plain-v0:invalid-crds-and-crs --name $(KIND_CLUSTER_NAME)
-	$(KIND) load docker-image testdata/bundles/plain-v0:subdir --name $(KIND_CLUSTER_NAME)
-	$(KIND) load docker-image testdata/bundles/registry:valid --name $(KIND_CLUSTER_NAME)
-	$(KIND) load docker-image testdata/bundles/registry:invalid --name $(KIND_CLUSTER_NAME)
+	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/valid -t localhost/testdata/bundles/plain-v0:valid
+	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/dependent -t localhost/testdata/bundles/plain-v0:dependent
+	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/provides -t localhost/testdata/bundles/plain-v0:provides
+	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/empty -t localhost/testdata/bundles/plain-v0:empty
+	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/no-manifests -t localhost/testdata/bundles/plain-v0:no-manifests
+	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/invalid-missing-crds -t localhost/testdata/bundles/plain-v0:invalid-missing-crds
+	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/invalid-crds-and-crs -t localhost/testdata/bundles/plain-v0:invalid-crds-and-crs
+	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/plain-v0/subdir -t localhost/testdata/bundles/plain-v0:subdir
+	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/registry/valid -t localhost/testdata/bundles/registry:valid
+	$(CONTAINER_RUNTIME) build $(TESTDATA_DIR)/bundles/registry/invalid -t localhost/testdata/bundles/registry:invalid
+	$(KIND) load docker-image localhost/testdata/bundles/plain-v0:valid --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image localhost/testdata/bundles/plain-v0:dependent --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image localhost/testdata/bundles/plain-v0:provides --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image localhost/testdata/bundles/plain-v0:empty --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image localhost/testdata/bundles/plain-v0:no-manifests --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image localhost/testdata/bundles/plain-v0:invalid-missing-crds --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image localhost/testdata/bundles/plain-v0:invalid-crds-and-crs --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image localhost/testdata/bundles/plain-v0:subdir --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image localhost/testdata/bundles/registry:valid --name $(KIND_CLUSTER_NAME)
+	$(KIND) load docker-image localhost/testdata/bundles/registry:invalid --name $(KIND_CLUSTER_NAME)
 
 kind-load: kind ## Loads the currently constructed image onto the cluster
 	$(KIND) load docker-image $(IMAGE) --name $(KIND_CLUSTER_NAME)
 
 registry-load-bundles: ## Load selected e2e testdata container images created in kind-load-bundles into registry
-	$(CONTAINER_RUNTIME) tag testdata/bundles/plain-v0:valid $(DNS_NAME):5000/bundles/plain-v0:valid
+	$(CONTAINER_RUNTIME) tag localhost/testdata/bundles/plain-v0:valid $(DNS_NAME):5000/bundles/plain-v0:valid
 	./test/tools/imageregistry/load_test_image.sh $(KIND) $(KIND_CLUSTER_NAME)
 
 ###########

--- a/test/e2e/api_validation_test.go
+++ b/test/e2e/api_validation_test.go
@@ -34,7 +34,7 @@ var _ = Describe("bundle api validation", func() {
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
-							Ref: "testdata/bundles/plain-v0:valid",
+							Ref: "localhost/testdata/bundles/plain-v0:valid",
 						},
 					},
 				},
@@ -69,7 +69,7 @@ var _ = Describe("bundle api validation", func() {
 					Source: rukpakv1alpha1.BundleSource{
 						Type: "invalid source",
 						Image: &rukpakv1alpha1.ImageSource{
-							Ref: "testdata/bundles/plain-v0:valid",
+							Ref: "localhost/testdata/bundles/plain-v0:valid",
 						},
 						Git: &rukpakv1alpha1.GitSource{
 							Repository: "https://github.com/exdx/combo-bundle",
@@ -226,7 +226,7 @@ var _ = Describe("bundle api validation", func() {
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
-							Ref: "testdata/bundles/plain-v0:valid",
+							Ref: "localhost/testdata/bundles/plain-v0:valid",
 						},
 					},
 				},
@@ -263,7 +263,7 @@ var _ = Describe("bundle deployment api validation", func() {
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
-									Ref: "testdata/bundles/plain-v0:valid",
+									Ref: "localhost/testdata/bundles/plain-v0:valid",
 								},
 							},
 						},
@@ -308,7 +308,7 @@ var _ = Describe("bundle deployment api validation", func() {
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
-									Ref: "testdata/bundles/plain-v0:valid",
+									Ref: "localhost/testdata/bundles/plain-v0:valid",
 								},
 							},
 						},
@@ -350,7 +350,7 @@ var _ = Describe("bundle deployment api validation", func() {
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
-									Ref: "testdata/bundles/plain-v0:valid",
+									Ref: "localhost/testdata/bundles/plain-v0:valid",
 								},
 							},
 						},

--- a/test/e2e/image_repo.go
+++ b/test/e2e/image_repo.go
@@ -2,4 +2,4 @@ package e2e
 
 // ImageRepo is meant to be set via -ldflags during execution of this code
 // where it will then be used to configure the testing suite.
-var ImageRepo = "testdata/bundles"
+var ImageRepo = "localhost/testdata/bundles"

--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -33,7 +33,7 @@ var _ = Describe("bundle api validating webhook", func() {
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
-							Ref: "testdata/bundles/plain-v0:valid",
+							Ref: "localhost/testdata/bundles/plain-v0:valid",
 						},
 					},
 				},
@@ -68,7 +68,7 @@ var _ = Describe("bundle api validating webhook", func() {
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeGit,
 						Image: &rukpakv1alpha1.ImageSource{
-							Ref: "testdata/bundles/plain-v0:valid",
+							Ref: "localhost/testdata/bundles/plain-v0:valid",
 						},
 					},
 				},

--- a/test/tools/git/git.yaml
+++ b/test/tools/git/git.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: git
-    image: git:latest
+    image: localhost/git:latest
     imagePullPolicy: IfNotPresent
     ports:
     - containerPort: 22

--- a/test/tools/git/setup_git.sh
+++ b/test/tools/git/setup_git.sh
@@ -19,8 +19,8 @@ rm -rf test/tools/git/tmp
 git clone https://github.com/operator-framework/combo.git test/tools/git/testdata/combo
 
 # create docker image
-docker build -t git:latest test/tools/git/
-kind load docker-image git:latest --name $KIND_CLUSTER_NAME
+docker build -t localhost/git:latest test/tools/git/
+kind load docker-image localhost/git:latest --name $KIND_CLUSTER_NAME
 
 # create image registry service
 kubectl apply -f test/tools/git/service.yaml -n $GIT_NAMESPACE

--- a/test/tools/imageregistry/sniff.sh
+++ b/test/tools/imageregistry/sniff.sh
@@ -8,9 +8,9 @@ export KIND_CLUSTER_NAME=$1
 # push test bundle image into in-cluster docker registry
 kubectl exec nerdctl -n $REGISTRY_NAMESPACE -- sh -c "nerdctl login -u myuser -p mypasswd $DNS_NAME:5000 --insecure-registry"
 
-docker build testdata/bundles/plain-v0/valid -t testdata/bundles/plain-v0:valid
-kind load docker-image testdata/bundles/plain-v0:valid --name $KIND_CLUSTER_NAME
-kubectl exec nerdctl -n $REGISTRY_NAMESPACE -- sh -c "nerdctl -n k8s.io tag testdata/bundles/plain-v0:valid $DNS_NAME:5000/bundles/plain-v0:valid"
+docker build testdata/bundles/plain-v0/valid -t localhost/testdata/bundles/plain-v0:valid
+kind load docker-image localhost/testdata/bundles/plain-v0:valid --name $KIND_CLUSTER_NAME
+kubectl exec nerdctl -n $REGISTRY_NAMESPACE -- sh -c "nerdctl -n k8s.io tag localhost/testdata/bundles/plain-v0:valid $DNS_NAME:5000/bundles/plain-v0:valid"
 kubectl exec nerdctl -n $REGISTRY_NAMESPACE -- sh -c "nerdctl -n k8s.io push $DNS_NAME:5000/bundles/plain-v0:valid --insecure-registry"
 kubectl exec nerdctl -n $REGISTRY_NAMESPACE -- sh -c "nerdctl -n k8s.io rmi $DNS_NAME:5000/bundles/plain-v0:valid --insecure-registry"
 


### PR DESCRIPTION
Explicitly specify localhost for some containers, otherwise docker.io ends up being used as the default repository.