### PR TITLE
Move to the new Kubernetes image repository

### DIFF
--- a/test/tools/imageregistry/daemonset.yaml
+++ b/test/tools/imageregistry/daemonset.yaml
@@ -43,4 +43,4 @@ spec:
           privileged: true
       containers:
       - name: wait
-        image: k8s.gcr.io/pause:3.1
+        image: registry.k8s.io/pause:3.1


### PR DESCRIPTION
Problem: The Kubernetes project is moving its images from the k8s.gcr.io registry to the registry.k8s.io registry and our project relies on one of the images being moved. More information can be found here: https://github.com/kubernetes/k8s.io/issues/4780

Solution: Update the referenced image to point to the same image hosted at the new registry.