### PR TITLE
fix: use multi-arch alpine image for git test server

### DIFF
--- a/test/tools/git/Dockerfile
+++ b/test/tools/git/Dockerfile
@@ -1,23 +1,10 @@
-FROM alpine:3.4
-
-# "--no-cache" is new in Alpine 3.3 and it avoid using
-# "--update + rm -rf /var/cache/apk/*" (to remove cache)
-RUN apk add --no-cache \
-# openssh=7.2_p2-r1 \
-  openssh \
-# git=2.8.3-r0
-  git
-
-RUN ssh-keygen -A
-
-# SSH autorun
-# RUN rc-update add sshd
+FROM alpine:3
 
 WORKDIR /git-server/
 
-# -D flag avoids password generation
-# -s flag changes user's shell
-RUN mkdir /git-server/keys \
+RUN apk add --no-cache openssh git \
+  && ssh-keygen -A \
+  && mkdir /git-server/keys \
   && adduser -D -s /usr/bin/git-shell git \
   && echo git:12345 | chpasswd \
   && mkdir /home/git/.ssh


### PR DESCRIPTION
I noticed that running `make e2e` locally on my Mac M1 machine would always fail the git+ssh source test because `alpine:3.4` is not a multi-arch image, so there were no runnable images for my machine (I need linux/arm64).

In this PR, I bump the git Dockerfile to use `alpine:3`, which _does_ have an arm64 image. I also simplify other aspects of the Makefile and remove unnecessary comment lines.