### PR TITLE
version: use go1.18+ embedded build info

### DIFF
--- a/.goreleaser.template.yml
+++ b/.goreleaser.template.yml
@@ -19,8 +19,6 @@ builds:
     - arm64
     - ppc64le
     - s390x
-    ldflags:
-    - -X {{ .Env.PKG }}.GitCommit={{ .ShortCommit }}
   - id: helm
     main: ./cmd/helm
     binary: helm
@@ -32,8 +30,6 @@ builds:
       - arm64
       - ppc64le
       - s390x
-    ldflags:
-      - -X {{ .Env.PKG }}.GitCommit={{ .ShortCommit }}
   - id: core
     main: ./cmd/core
     binary: core
@@ -45,8 +41,6 @@ builds:
     - arm64
     - ppc64le
     - s390x
-    ldflags:
-    - -X {{ .Env.PKG }}.GitCommit={{ .ShortCommit }}
   - id: webhooks
     main: ./cmd/webhooks
     binary: webhooks
@@ -58,8 +52,6 @@ builds:
       - arm64
       - ppc64le
       - s390x
-    ldflags:
-      - -X {{ .Env.PKG }}.GitCommit={{ .ShortCommit }}
   - id: crdvalidator
     main: ./cmd/crdvalidator
     binary: crdvalidator
@@ -71,8 +63,6 @@ builds:
     - arm64
     - ppc64le
     - s390x
-    ldflags:
-    - -X {{ .Env.PKG }}.GitCommit={{ .ShortCommit }}
   - id: rukpakctl
     main: ./cmd/rukpakctl
     binary: rukpakctl
@@ -84,8 +74,6 @@ builds:
       - arm64
       - ppc64le
       - s390x
-    ldflags:
-      - -X {{ .Env.PKG }}.GitCommit={{ .ShortCommit }}
 dockers:
 - image_templates:
   - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-amd64"

--- a/Makefile
+++ b/Makefile
@@ -170,16 +170,14 @@ LINUX_BINARIES=$(join $(addprefix linux/,$(BINARIES)), )
 
 .PHONY: build $(BINARIES) $(LINUX_BINARIES) build-container kind-load kind-load-bundles kind-cluster registry-load-bundles
 
-VERSION_FLAGS=-ldflags "-X $(VERSION_PATH).GitCommit=$(GIT_COMMIT)"
-
 # Binary builds
 build: $(BINARIES)
 
 $(LINUX_BINARIES):
-	CGO_ENABLED=0 GOOS=linux go build $(DEBUG_FLAGS) -tags $(GO_BUILD_TAGS) $(VERSION_FLAGS) -o $(BIN_DIR)/$@ ./cmd/$(notdir $@) 
+	CGO_ENABLED=0 GOOS=linux go build $(DEBUG_FLAGS) -tags $(GO_BUILD_TAGS) -o $(BIN_DIR)/$@ ./cmd/$(notdir $@)
 
 $(BINARIES):
-	CGO_ENABLED=0 go build $(DEBUG_FLAGS) -tags $(GO_BUILD_TAGS) $(VERSION_FLAGS) -o $(BIN_DIR)/$@ ./cmd/$@ $(DEBUG_FLAGS)
+	CGO_ENABLED=0 go build $(DEBUG_FLAGS) -tags $(GO_BUILD_TAGS) -o $(BIN_DIR)/$@ ./cmd/$@ $(DEBUG_FLAGS)
 
 build-container: $(LINUX_BINARIES) ## Builds provisioner container image locally
 	$(CONTAINER_RUNTIME) build -f Dockerfile -t $(IMAGE) $(BIN_DIR)/linux

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -102,7 +102,7 @@ func main() {
 	flag.Parse()
 
 	if rukpakVersion {
-		fmt.Printf("Git commit: %s\n", version.String())
+		fmt.Println(version.String())
 		os.Exit(0)
 	}
 

--- a/cmd/helm/main.go
+++ b/cmd/helm/main.go
@@ -92,7 +92,7 @@ func main() {
 	flag.Parse()
 
 	if rukpakVersion {
-		fmt.Printf("Git commit: %s\n", version.String())
+		fmt.Println(version.String())
 		os.Exit(0)
 	}
 

--- a/cmd/rukpakctl/cmd/root.go
+++ b/cmd/rukpakctl/cmd/root.go
@@ -26,6 +26,7 @@ to quickly create a Cobra application.`,
 	rootCmd.AddCommand(
 		newContentCmd(),
 		newRunCmd(),
+		newVersionCmd(),
 	)
 
 	// Only add the alpha command if its non-nil. It will be nil if

--- a/cmd/rukpakctl/cmd/version.go
+++ b/cmd/rukpakctl/cmd/version.go
@@ -1,6 +1,19 @@
 /*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+Copyright 2023 The Operator Framework Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
+
 package cmd
 
 import (

--- a/cmd/rukpakctl/cmd/version.go
+++ b/cmd/rukpakctl/cmd/version.go
@@ -1,0 +1,24 @@
+/*
+Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/operator-framework/rukpak/internal/version"
+)
+
+// newVersionCmd creates the version command
+func newVersionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print the rukpakctl version information.",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(version.String())
+		},
+	}
+	return cmd
+}

--- a/cmd/unpack/main.go
+++ b/cmd/unpack/main.go
@@ -36,7 +36,7 @@ func main() {
 		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if rukpakVersion {
-				fmt.Printf("Git commit: %s\n", version.String())
+				fmt.Println(version.String())
 				os.Exit(0)
 			}
 			var err error

--- a/cmd/webhooks/main.go
+++ b/cmd/webhooks/main.go
@@ -61,7 +61,7 @@ func main() {
 	flag.Parse()
 
 	if rukpakVersion {
-		fmt.Printf("Git commit: %s\n", version.String())
+		fmt.Println(version.String())
 		os.Exit(0)
 	}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,11 +5,15 @@ import (
 	"runtime/debug"
 )
 
-// GitCommit indicates which commit the rukpak binaries were built from
 var (
-	gitCommit  string = "unknown"
-	commitDate string = "unknown"
-	repoState  string = "unknown"
+	gitCommit  = "unknown"
+	commitDate = "unknown"
+	repoState  = "unknown"
+
+	stateMap = map[string]string{
+		"true":  "dirty",
+		"false": "clean",
+	}
 )
 
 func String() string {
@@ -28,13 +32,8 @@ func init() {
 		case "vcs.time":
 			commitDate = setting.Value
 		case "vcs.modified":
-			switch setting.Value {
-			case "false":
-				repoState = "clean"
-			case "true":
-				repoState = "dirty"
-			default:
-				repoState = "unknown"
+			if v, ok := stateMap[setting.Value]; ok {
+				repoState = v
 			}
 		}
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,8 +1,41 @@
 package version
 
+import (
+	"fmt"
+	"runtime/debug"
+)
+
 // GitCommit indicates which commit the rukpak binaries were built from
-var GitCommit string
+var (
+	gitCommit  string = "unknown"
+	commitDate string = "unknown"
+	repoState  string = "unknown"
+)
 
 func String() string {
-	return GitCommit
+	return fmt.Sprintf("revision: %q, date: %q, state: %q", gitCommit, commitDate, repoState)
+}
+
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			gitCommit = setting.Value
+		case "vcs.time":
+			commitDate = setting.Value
+		case "vcs.modified":
+			switch setting.Value {
+			case "false":
+				repoState = "clean"
+			case "true":
+				repoState = "dirty"
+			default:
+				repoState = "unknown"
+			}
+		}
+	}
 }


### PR DESCRIPTION
@everettraven Gave me some inspiration in operator-framework/catalogd#46 to simplify rukpak's version handling/printing.