### PR TITLE
Don't swallow the not-found error

### DIFF
--- a/internal/crd/crd.go
+++ b/internal/crd/crd.go
@@ -37,7 +37,7 @@ import (
 func Validate(ctx context.Context, cl client.Client, newCrd *apiextensionsv1.CustomResourceDefinition) error {
 	oldCRD := &apiextensionsv1.CustomResourceDefinition{}
 
-	err := client.IgnoreNotFound(cl.Get(ctx, client.ObjectKeyFromObject(newCrd), oldCRD))
+	err := cl.Get(ctx, client.ObjectKeyFromObject(newCrd), oldCRD)
 	if apierrors.IsNotFound(err) {
 		// Return early if the CRD has not been created yet
 		// as we know it is valid.


### PR DESCRIPTION
Don't swallow the not-found error because doing so leads the following check to see if it's a not-found error to always fail.