### PR TITLE
[fix] Fix tag of default unpack image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 ORG := github.com/operator-framework
 PKG := $(ORG)/rukpak
 export IMAGE_REPO ?= quay.io/operator-framework/rukpak
-export IMAGE_TAG ?= latest
+export IMAGE_TAG ?= devel
 export GO_BUILD_TAGS ?= ''
 IMAGE?=$(IMAGE_REPO):$(IMAGE_TAG)
 KIND_CLUSTER_NAME ?= rukpak
@@ -224,7 +224,7 @@ release: goreleaser ## Run goreleaser
 
 quickstart: VERSION ?= $(shell git describe --abbrev=0 --tags)
 quickstart: generate ## Generate the installation release manifests
-	$(KUBECTL) kustomize manifests | sed "s/:latest/:$(VERSION)/g" > rukpak.yaml
+	$(KUBECTL) kustomize manifests | sed "s/:devel/:$(VERSION)/g" > rukpak.yaml
 
 ################
 # Hack / Tools #

--- a/internal/util/defaults.go
+++ b/internal/util/defaults.go
@@ -2,6 +2,6 @@ package util
 
 const (
 	DefaultSystemNamespace   = "rukpak-system"
-	DefaultUnpackImage       = "quay.io/operator-framework/rukpak:latest"
+	DefaultUnpackImage       = "quay.io/operator-framework/rukpak:main"
 	DefaultUploadServiceName = "core"
 )

--- a/manifests/apis/webhooks/resources/deployment.yaml
+++ b/manifests/apis/webhooks/resources/deployment.yaml
@@ -27,7 +27,7 @@ spec:
             capabilities:
               drop: [ "ALL" ]
           command: ["/webhooks"]
-          image: quay.io/operator-framework/rukpak:latest
+          image: quay.io/operator-framework/rukpak:devel
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/manifests/core/resources/deployment.yaml
+++ b/manifests/core/resources/deployment.yaml
@@ -53,11 +53,11 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ "ALL" ]
-          image: quay.io/operator-framework/rukpak:latest
+          image: quay.io/operator-framework/rukpak:devel
           imagePullPolicy: IfNotPresent
           command: ["/core"]
           args:
-            - "--unpack-image=quay.io/operator-framework/rukpak:latest"
+            - "--unpack-image=quay.io/operator-framework/rukpak:devel"
             - "--base-upload-manager-url=https://$(CORE_SERVICE_NAME).$(CORE_SERVICE_NAMESPACE).svc"
             - "--provisioner-storage-dir=/var/cache/bundles"
             - "--upload-storage-dir=/var/cache/uploads"

--- a/manifests/crdvalidator/05_deployment.yaml
+++ b/manifests/crdvalidator/05_deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       serviceAccountName: crd-validation-webhook
       containers:
-        - image: quay.io/operator-framework/rukpak:latest
+        - image: quay.io/operator-framework/rukpak:devel
           imagePullPolicy: IfNotPresent
           command: ["/crdvalidator"]
           name: crd-validation-webhook

--- a/manifests/provisioners/helm/resources/deployment.yaml
+++ b/manifests/provisioners/helm/resources/deployment.yaml
@@ -53,11 +53,11 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ "ALL" ]
-          image: quay.io/operator-framework/rukpak:latest
+          image: quay.io/operator-framework/rukpak:devel
           imagePullPolicy: IfNotPresent
           command: ["/helm"]
           args:
-            - "--unpack-image=quay.io/operator-framework/rukpak:latest"
+            - "--unpack-image=quay.io/operator-framework/rukpak:devel"
             - "--base-upload-manager-url=https://$(CORE_SERVICE_NAME).$(CORE_SERVICE_NAMESPACE).svc"
             - "--storage-dir=/var/cache/bundles"
             - "--http-bind-address=127.0.0.1:8080"


### PR DESCRIPTION
The default tag for unpack image is currently "latest". Based on the recently built images in quay:
https://quay.io/repository/operator-framework/rukpak?tab=tags it looks like the "latest" tag does not exist. Instead "main" is used. This PR fixes the same.