### PR TITLE
Replaces super linter with markdown linter

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -35,11 +35,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Lint markdown files
-        uses: github/super-linter/slim@v4
-        env:
-          VALIDATE_ALL_CODEBASE: true
-          FILTER_REGEX_EXCLUDE: .*\.bingo/.*
-          DEFAULT_BRANCH: main
-          # only runs the markdown linter
-          VALIDATE_MARKDOWN: true
+      - uses: DavidAnson/markdownlint-cli2-action@v11
+        with:
+          config: .markdownlint.yaml
+          globs: |
+            **/*.md
+            !.bingo

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,7 @@
+# Rules by id
+MD013:
+  line_length: 300
+MD029: false
+
+# Rules by groups
+blank_lines: false


### PR DESCRIPTION
We use super-linter only to lint markdown files. New GitHub Action uses the smaeUnderlying linter (markdownlint), but it provides better output support: PRs get annotations from CI jobs when there is an linting issue.

Also this action is much faster then super-linter: at the moment of writing it takes 4-6 seconds when super-linter slim image takes 90-110 seconds.