### PR TITLE
Fixes `make lint` when run without args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,6 @@ help: ## Show this help screen
 
 ##@ code management:
 
-lint: GOLANGCI_LINT_ARGS ?= ''
 lint: $(GOLANGCI_LINT) ## Run golangci linter
 	$(Q)$(GOLANGCI_LINT) run --build-tags $(GO_BUILD_TAGS) $(GOLANGCI_LINT_ARGS)
 


### PR DESCRIPTION
In #631 I added an optional `GOLANGCI_LINT_ARGS` into `make lint`, but... When you run `make lint` you get this:

```
ERRO Running error: context loading failed: failed to load packages: package .: no go files to analyze
```

This should fix it.

Example runs:
```
make lint
make lint GOLANGCI_LINT_ARGS="--verbose"
make lint GOLANGCI_LINT_ARGS="--out-format github-actions"
```