### PR TITLE
Adds `ginkgolinter`

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,7 @@ linters:
   - asciicheck
   - bodyclose
   - errorlint
+  - ginkgolinter
   - gofmt
   - goimports
   - gosec

--- a/internal/storage/http_test.go
+++ b/internal/storage/http_test.go
@@ -52,7 +52,7 @@ var _ = Describe("HTTP", func() {
 		// Populate the content URL, this has to happen after the server has
 		// started so that we know the server's base URL.
 		contentURL, err := localStore.URLFor(ctx, bundle)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		bundle.Status.ContentURL = contentURL
 	})
 	AfterEach(func() {
@@ -89,7 +89,7 @@ var _ = Describe("HTTP", func() {
 					store := NewHTTP(opts...)
 					loadedTestFS, err := store.Load(ctx, bundle)
 					Expect(fsEqual(testFS, loadedTestFS)).To(BeTrue())
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 				})
 			})
 			Context("with non-existing bundle", func() {
@@ -132,7 +132,7 @@ var _ = Describe("HTTP", func() {
 					store := NewHTTP(opts...)
 					loadedTestFS, err := store.Load(ctx, bundle)
 					Expect(fsEqual(testFS, loadedTestFS)).To(BeTrue())
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 				})
 			})
 			Context("with non-existing bundle", func() {

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -60,13 +60,13 @@ var _ = Describe("WithFallbackLoader", func() {
 
 	It("should find primary bundle", func() {
 		loadedTestFS, err := store.Load(ctx, primaryBundle)
-		Expect(err).To(BeNil())
-		Expect(fsEqual(primaryFS, loadedTestFS))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fsEqual(primaryFS, loadedTestFS)).To(BeTrue())
 	})
 	It("should find fallback bundle", func() {
 		loadedTestFS, err := store.Load(ctx, fallbackBundle)
-		Expect(err).To(BeNil())
-		Expect(fsEqual(fallbackFS, loadedTestFS))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fsEqual(fallbackFS, loadedTestFS)).To(BeTrue())
 	})
 	It("should fail to find unknown bundle", func() {
 		unknownBundle := &rukpakv1alpha1.Bundle{

--- a/test/e2e/crdvalidator_test.go
+++ b/test/e2e/crdvalidator_test.go
@@ -48,7 +48,7 @@ var _ = Describe("crdvalidator", func() {
 
 			AfterEach(func() {
 				By("deleting the testing crd")
-				Expect(c.Delete(ctx, crd)).To(BeNil())
+				Expect(c.Delete(ctx, crd)).To(Succeed())
 			})
 
 			It("should allow the crd update event to occur without being owned by RukPak", func() {
@@ -139,7 +139,7 @@ var _ = Describe("crdvalidator", func() {
 
 			AfterEach(func() {
 				By("deleting the testing crd")
-				Expect(c.Delete(ctx, crd)).To(BeNil())
+				Expect(c.Delete(ctx, crd)).To(Succeed())
 			})
 
 			It("should be invalidated if owned by RukPak", func() {
@@ -167,7 +167,7 @@ var _ = Describe("crdvalidator", func() {
 
 					// Remove the "core.rukpak.io/owner-kind" label
 					crd.Labels = map[string]string{}
-					Expect(c.Update(ctx, crd)).To(BeNil())
+					Expect(c.Update(ctx, crd)).To(Succeed())
 
 					// Update the v1alpha1 schema to invalidate existing CR created in BeforeEach()
 					crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Required = []string{"sampleProperty"}
@@ -184,7 +184,7 @@ var _ = Describe("crdvalidator", func() {
 
 					// Add the "core.rukpak.io/safe-upgrade-validation" label set to "disabled"
 					crd.Annotations = map[string]string{annotation.ValidationKey: annotation.Disabled}
-					Expect(c.Update(ctx, crd)).To(BeNil())
+					Expect(c.Update(ctx, crd)).To(Succeed())
 
 					// Update the v1alpha1 schema to invalidate existing CR created in BeforeEach()
 					crd.Spec.Versions[0].Schema.OpenAPIV3Schema.Required = []string{"sampleProperty"}
@@ -241,7 +241,7 @@ var _ = Describe("crdvalidator", func() {
 
 			AfterEach(func() {
 				By("deleting the testing crd")
-				Expect(c.Delete(ctx, crd)).To(BeNil())
+				Expect(c.Delete(ctx, crd)).To(Succeed())
 			})
 
 			It("should deny admission", func() {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -38,28 +38,18 @@ var _ = BeforeSuite(func() {
 	cfg = ctrl.GetConfigOrDie()
 
 	scheme := runtime.NewScheme()
-	err := rukpakv1alpha1.AddToScheme(scheme)
-	Expect(err).To(BeNil())
-	err = rbacv1.AddToScheme(scheme)
-	Expect(err).To(BeNil())
-	err = batchv1.AddToScheme(scheme)
-	Expect(err).To(BeNil())
+	Expect(rukpakv1alpha1.AddToScheme(scheme)).To(Succeed())
+	Expect(rbacv1.AddToScheme(scheme)).To(Succeed())
+	Expect(batchv1.AddToScheme(scheme)).To(Succeed())
+	Expect(operatorsv1.AddToScheme(scheme)).To(Succeed())
+	Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	Expect(appsv1.AddToScheme(scheme)).To(Succeed())
+	Expect(apiextensionsv1.AddToScheme(scheme)).To(Succeed())
 
-	err = operatorsv1.AddToScheme(scheme)
-	Expect(err).To(BeNil())
-
-	err = corev1.AddToScheme(scheme)
-	Expect(err).To(BeNil())
-
-	err = appsv1.AddToScheme(scheme)
-	Expect(err).To(BeNil())
-
-	err = apiextensionsv1.AddToScheme(scheme)
-	Expect(err).To(BeNil())
-
+	var err error
 	c, err = client.New(cfg, client.Options{Scheme: scheme})
-	Expect(err).To(BeNil())
+	Expect(err).ToNot(HaveOccurred())
 
 	kubeClient, err = kubernetes.NewForConfig(cfg)
-	Expect(err).To(BeNil())
+	Expect(err).ToNot(HaveOccurred())
 })

--- a/test/e2e/helm_provisioner_test.go
+++ b/test/e2e/helm_provisioner_test.go
@@ -52,11 +52,11 @@ var _ = Describe("helm provisioner bundledeployment", func() {
 				},
 			}
 			err := c.Create(ctx, bd)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing resources")
-			Expect(c.Delete(ctx, bd)).To(BeNil())
+			Expect(c.Delete(ctx, bd)).To(Succeed())
 		})
 
 		It("should rollout the bundle contents successfully", func() {
@@ -109,7 +109,7 @@ var _ = Describe("helm provisioner bundledeployment", func() {
 				}).Should(Succeed())
 
 				By("deleting the deployment resource in the helm chart")
-				Expect(c.Delete(ctx, deployment)).To(BeNil())
+				Expect(c.Delete(ctx, deployment)).To(Succeed())
 
 				By("verifying the deleted deployment resource in the helm chart gets recreated")
 				Eventually(func() (*appsv1.DeploymentCondition, error) {
@@ -166,11 +166,11 @@ var _ = Describe("helm provisioner bundledeployment", func() {
 				},
 			}
 			err := c.Create(ctx, bd)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing resources")
-			Expect(c.Delete(ctx, bd)).To(BeNil())
+			Expect(c.Delete(ctx, bd)).To(Succeed())
 		})
 
 		It("should fail rolling out the bundle contents", func() {
@@ -222,11 +222,11 @@ var _ = Describe("helm provisioner bundledeployment", func() {
 				},
 			}
 			err := c.Create(ctx, bd)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing resources")
-			Expect(c.Delete(ctx, bd)).To(BeNil())
+			Expect(c.Delete(ctx, bd)).To(Succeed())
 		})
 
 		It("should fail rolling out the bundle contents", func() {
@@ -278,11 +278,11 @@ var _ = Describe("helm provisioner bundledeployment", func() {
 				},
 			}
 			err := c.Create(ctx, bd)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing resources")
-			Expect(c.Delete(ctx, bd)).To(BeNil())
+			Expect(c.Delete(ctx, bd)).To(Succeed())
 		})
 
 		It("should fail rolling out the bundle contents", func() {
@@ -338,11 +338,11 @@ var _ = Describe("helm provisioner bundledeployment", func() {
 				},
 			}
 			err := c.Create(ctx, bd)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing resources")
-			Expect(c.Delete(ctx, bd)).To(BeNil())
+			Expect(c.Delete(ctx, bd)).To(Succeed())
 		})
 
 		It("should rollout the bundle contents successfully", func() {
@@ -402,7 +402,7 @@ var _ = Describe("helm provisioner bundledeployment", func() {
 				}).Should(Succeed())
 
 				By("deleting the deployment resource in the helm chart")
-				Expect(c.Delete(ctx, deployment)).To(BeNil())
+				Expect(c.Delete(ctx, deployment)).To(Succeed())
 
 				By("verifying the deleted deployment resource in the helm chart gets recreated")
 				Eventually(func() (*appsv1.DeploymentCondition, error) {
@@ -462,11 +462,11 @@ var _ = Describe("helm provisioner bundledeployment", func() {
 				},
 			}
 			err := c.Create(ctx, bd)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing resources")
-			Expect(c.Delete(ctx, bd)).To(BeNil())
+			Expect(c.Delete(ctx, bd)).To(Succeed())
 		})
 
 		It("should rollout the bundle contents successfully", func() {
@@ -522,11 +522,11 @@ var _ = Describe("helm provisioner bundledeployment", func() {
 				},
 			}
 			err := c.Create(ctx, bd)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing resources")
-			Expect(c.Delete(ctx, bd)).To(BeNil())
+			Expect(c.Delete(ctx, bd)).To(Succeed())
 		})
 
 		It("should rollout the bundle contents successfully", func() {

--- a/test/e2e/plain_provisioner_test.go
+++ b/test/e2e/plain_provisioner_test.go
@@ -74,12 +74,12 @@ var _ = Describe("plain provisioner bundle", func() {
 				},
 			}
 			err := c.Create(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing Bundle resource")
 			err := c.Delete(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		It("should consistently contain an empty status", func() {
 			Consistently(func() bool {
@@ -114,12 +114,12 @@ var _ = Describe("plain provisioner bundle", func() {
 				},
 			}
 			err := c.Create(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing Bundle resource")
 			err := c.Delete(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should eventually report a successful state", func() {
@@ -176,7 +176,7 @@ var _ = Describe("plain provisioner bundle", func() {
 
 			By("deleting the underlying pod and waiting for it to be re-created")
 			err := c.Delete(context.Background(), pod)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			By("verifying the pod's UID has changed")
 			Eventually(func() (types.UID, error) {
@@ -233,12 +233,12 @@ var _ = Describe("plain provisioner bundle", func() {
 				},
 			}
 			err := c.Create(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing Bundle resource")
 			err := c.Delete(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should eventually report a successful state", func() {
@@ -293,12 +293,12 @@ var _ = Describe("plain provisioner bundle", func() {
 				},
 			}
 			err := c.Create(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing Bundle resource")
 			err := c.Delete(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("checks the bundle's phase is stuck in pending", func() {
@@ -367,12 +367,12 @@ var _ = Describe("plain provisioner bundle", func() {
 				},
 			}
 			err := c.Create(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing Bundle resource")
 			err := c.Delete(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		It("reports an unpack error when the manifests directory is missing", func() {
 			By("waiting for the bundle to report back that state")
@@ -416,12 +416,12 @@ var _ = Describe("plain provisioner bundle", func() {
 				},
 			}
 			err := c.Create(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing Bundle resource")
 			err := c.Delete(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		It("reports an unpack error when the manifests directory contains no objects", func() {
 			By("waiting for the bundle to report back that state")
@@ -473,12 +473,12 @@ var _ = Describe("plain provisioner bundle", func() {
 					},
 				}
 				err := c.Create(ctx, bundle)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			AfterEach(func() {
 				err := c.Delete(ctx, bundle)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("Can create and unpack the bundle successfully", func() {
@@ -525,12 +525,12 @@ var _ = Describe("plain provisioner bundle", func() {
 					},
 				}
 				err := c.Create(ctx, bundle)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			AfterEach(func() {
 				err := c.Delete(ctx, bundle)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("Can create and unpack the bundle successfully", func() {
@@ -596,12 +596,12 @@ var _ = Describe("plain provisioner bundle", func() {
 					},
 				}
 				err := c.Create(ctx, bundle)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			AfterEach(func() {
 				err := c.Delete(ctx, bundle)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("Can create and unpack the bundle successfully", func() {
@@ -668,12 +668,12 @@ var _ = Describe("plain provisioner bundle", func() {
 					},
 				}
 				err := c.Create(ctx, bundle)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			AfterEach(func() {
 				err := c.Delete(ctx, bundle)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("Can create and unpack the bundle successfully", func() {
@@ -711,7 +711,7 @@ var _ = Describe("plain provisioner bundle", func() {
 				if privateRepo == "" {
 					Skip("Private repository information is not set.")
 				}
-				Expect(privateRepo[:4] == "http").To(BeTrue())
+				Expect(privateRepo[:4]).To(Equal("http"))
 
 				secret = &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
@@ -722,7 +722,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					Type: "Opaque",
 				}
 				err := c.Create(ctx, secret)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				bundle = &rukpakv1alpha1.Bundle{
 					ObjectMeta: metav1.ObjectMeta{
 						GenerateName: "combo-git-branch",
@@ -746,14 +746,14 @@ var _ = Describe("plain provisioner bundle", func() {
 					},
 				}
 				err = c.Create(ctx, bundle)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			AfterEach(func() {
 				err := c.Delete(ctx, bundle)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				err = c.Delete(ctx, secret)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("Can create and unpack the bundle successfully", func() {
@@ -809,12 +809,12 @@ var _ = Describe("plain provisioner bundle", func() {
 					},
 				}
 				err := c.Create(ctx, bundle)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			AfterEach(func() {
 				err := c.Delete(ctx, bundle)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 
 			It("Can create and unpack the bundle successfully", func() {
@@ -869,7 +869,7 @@ var _ = Describe("plain provisioner bundle", func() {
 				data[info.Name()] = string(c)
 				return nil
 			})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			configmap = &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "bundle-configmap-valid-",
@@ -879,7 +879,7 @@ var _ = Describe("plain provisioner bundle", func() {
 				Immutable: pointer.Bool(true),
 			}
 			err = c.Create(ctx, configmap)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			bundle = &rukpakv1alpha1.Bundle{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "combo-local-",
@@ -896,7 +896,7 @@ var _ = Describe("plain provisioner bundle", func() {
 				},
 			}
 			err = c.Create(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		AfterEach(func() {
@@ -947,12 +947,12 @@ var _ = Describe("plain provisioner bundle", func() {
 				},
 			}
 			err := c.Create(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		AfterEach(func() {
 			err := c.Delete(ctx, bundle)
-			Expect(client.IgnoreNotFound(err)).To(BeNil())
+			Expect(client.IgnoreNotFound(err)).To(Succeed())
 		})
 		It("eventually results in a failing bundle state", func() {
 			By("waiting until the bundle is reporting Failing state")
@@ -996,7 +996,7 @@ var _ = Describe("plain provisioner bundle", func() {
 				data[info.Name()] = string(c)
 				return nil
 			})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			configmap = &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "bundle-configmap-invalid-",
@@ -1006,7 +1006,7 @@ var _ = Describe("plain provisioner bundle", func() {
 				Immutable: pointer.Bool(true),
 			}
 			err = c.Create(ctx, configmap)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			bundle = &rukpakv1alpha1.Bundle{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "combo-local-",
@@ -1023,7 +1023,7 @@ var _ = Describe("plain provisioner bundle", func() {
 				},
 			}
 			err = c.Create(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		AfterEach(func() {
@@ -1072,10 +1072,10 @@ var _ = Describe("plain provisioner bundle", func() {
 				},
 			}
 			err := c.Create(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			rootCAs, err := rukpakctl.GetClusterCA(ctx, c, types.NamespacedName{Namespace: defaultSystemNamespace, Name: "rukpak-ca"})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			bu := rukpakctl.BundleUploader{
 				UploadServiceName:      defaultUploadServiceName,
@@ -1086,12 +1086,12 @@ var _ = Describe("plain provisioner bundle", func() {
 			uploadCtx, cancel := context.WithTimeout(ctx, time.Second*5)
 			defer cancel()
 			_, err = bu.Upload(uploadCtx, bundle.Name, bundleFS)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		AfterEach(func() {
 			err := c.Delete(ctx, bundle)
-			Expect(client.IgnoreNotFound(err)).To(BeNil())
+			Expect(client.IgnoreNotFound(err)).To(Succeed())
 		})
 
 		It("can unpack the bundle successfully", func() {
@@ -1130,10 +1130,10 @@ var _ = Describe("plain provisioner bundle", func() {
 				},
 			}
 			err := c.Create(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			rootCAs, err := rukpakctl.GetClusterCA(ctx, c, types.NamespacedName{Namespace: defaultSystemNamespace, Name: "rukpak-ca"})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			bu := rukpakctl.BundleUploader{
 				UploadServiceName:      defaultUploadServiceName,
@@ -1144,11 +1144,11 @@ var _ = Describe("plain provisioner bundle", func() {
 			uploadCtx, cancel := context.WithTimeout(ctx, time.Second*5)
 			defer cancel()
 			_, err = bu.Upload(uploadCtx, bundle.Name, bundleFS)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			err := c.Delete(ctx, bundle)
-			Expect(client.IgnoreNotFound(err)).To(BeNil())
+			Expect(client.IgnoreNotFound(err)).To(Succeed())
 		})
 		It("checks the bundle's phase gets failing", func() {
 			By("waiting until the bundle is reporting Failing state")
@@ -1196,12 +1196,12 @@ var _ = Describe("plain provisioner bundle", func() {
 				},
 			}
 			err := c.Create(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing Bundle resource")
 			err := c.Delete(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		It("reports an unpack error when the manifests directory contains directories", func() {
 			By("eventually reporting an Unpacked phase", func() {
@@ -1247,7 +1247,7 @@ var _ = Describe("plain provisioner bundle", func() {
 				},
 			}
 			err := c.Create(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			By("eventually reporting an Unpacked phase", func() {
 				Eventually(func() (string, error) {
 					if err := c.Get(ctx, client.ObjectKeyFromObject(bundle), bundle); err != nil {
@@ -1260,14 +1260,14 @@ var _ = Describe("plain provisioner bundle", func() {
 			By("eventually writing a content URL to the status", func() {
 				Eventually(func() (string, error) {
 					err := c.Get(ctx, client.ObjectKeyFromObject(bundle), bundle)
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					return bundle.Status.ContentURL, nil
 				}).Should(Not(BeEmpty()))
 			})
 		})
 		AfterEach(func() {
 			err := c.Delete(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		When("start server for bundle contents", func() {
 			var (
@@ -1285,7 +1285,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					},
 				}
 				err := c.Create(ctx, &sa)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 
 				// Create a temporary ClusterRoleBinding to bind the ServiceAccount to bundle-reader ClusterRole
 				crb = rbacv1.ClusterRoleBinding{
@@ -1299,7 +1299,7 @@ var _ = Describe("plain provisioner bundle", func() {
 				}
 
 				err = c.Create(ctx, &crb)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				url := bundle.Status.ContentURL
 
 				// Create a Job that reads from the URL and outputs contents in the pod log
@@ -1327,7 +1327,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					},
 				}
 				err = c.Create(ctx, &job)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 				Eventually(func() (bool, error) {
 					err = c.Get(ctx, types.NamespacedName{Name: "rukpak-svr-job", Namespace: defaultSystemNamespace}, &job)
 					if err != nil {
@@ -1365,7 +1365,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					}
 					buf := new(bytes.Buffer)
 					_, err = buf.ReadFrom(logReader)
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 					return strings.Contains(buf.String(), "manifests/00_namespace.yaml") &&
 						strings.Contains(buf.String(), "manifests/01_cluster_role.yaml") &&
 						strings.Contains(buf.String(), "manifests/01_service_account.yaml") &&
@@ -1408,7 +1408,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 				},
 			}
 			err := c.Create(ctx, bd)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 
 			By("waiting until the BD reports a successful installation")
 			Eventually(func() (*metav1.Condition, error) {
@@ -1429,7 +1429,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 		})
 		AfterEach(func() {
 			By("deleting the testing BD resource")
-			Expect(c.Delete(ctx, bd)).To(BeNil())
+			Expect(c.Delete(ctx, bd)).To(Succeed())
 		})
 		It("should generate a Bundle that contains an owner reference", func() {
 			// Note: cannot use bd.GroupVersionKind() as the Kind/APIVersion fields
@@ -1644,11 +1644,11 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 				},
 			}
 			err := c.Create(ctx, bd)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing BD resource")
-			Expect(c.Delete(ctx, bd)).To(BeNil())
+			Expect(c.Delete(ctx, bd)).To(Succeed())
 		})
 
 		It("should rollout the bundle contents successfully", func() {
@@ -1703,7 +1703,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 				},
 			}
 			err := c.Create(ctx, bd)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing BundleDeployment resource")
@@ -1770,7 +1770,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 				},
 			}
 			err := c.Create(ctx, bd)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing BundleDeployment resource")
@@ -1834,11 +1834,11 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 				},
 			}
 			err := c.Create(ctx, dependentBD)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing dependent BundleDeployment resource")
-			Expect(client.IgnoreNotFound(c.Delete(ctx, dependentBD))).To(BeNil())
+			Expect(client.IgnoreNotFound(c.Delete(ctx, dependentBD))).To(Succeed())
 
 		})
 		When("the providing BundleDeployment does not exist", func() {
@@ -1891,11 +1891,11 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 					},
 				}
 				err := c.Create(ctx, providesBD)
-				Expect(err).To(BeNil())
+				Expect(err).ToNot(HaveOccurred())
 			})
 			AfterEach(func() {
 				By("deleting the testing providing BundleDeployment resource")
-				Expect(client.IgnoreNotFound(c.Delete(ctx, providesBD))).To(BeNil())
+				Expect(client.IgnoreNotFound(c.Delete(ctx, providesBD))).To(Succeed())
 
 			})
 			It("should eventually project a successful installation for the dependent BundleDeployment", func() {
@@ -1952,11 +1952,11 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 				},
 			}
 			err := c.Create(ctx, bd)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing BD resource")
-			Expect(c.Delete(ctx, bd)).To(BeNil())
+			Expect(c.Delete(ctx, bd)).To(Succeed())
 		})
 		It("eventually reports a failed installation state due to missing APIs on the cluster", func() {
 			Eventually(func() (*metav1.Condition, error) {
@@ -1999,7 +1999,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 					},
 				},
 			}
-			Expect(c.Create(ctx, b)).To(BeNil())
+			Expect(c.Create(ctx, b)).To(Succeed())
 
 			By("eventually reporting an Unpacked phase")
 			Eventually(func() (string, error) {
@@ -2015,7 +2015,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 		})
 		It("should result in the underlying bundle unpack pod being deleted", func() {
 			By("deleting the test Bundle resource")
-			Expect(c.Delete(ctx, b)).To(BeNil())
+			Expect(c.Delete(ctx, b)).To(Succeed())
 
 			By("waiting until the unpack pods for this bundle have been deleted")
 			selector := util.NewBundleLabelSelector(b)
@@ -2033,14 +2033,14 @@ var _ = Describe("plain provisioner garbage collection", func() {
 		It("should result in the underlying bundle file being deleted", func() {
 			provisionerPods := &corev1.PodList{}
 			err := c.List(context.Background(), provisionerPods, client.MatchingLabels{"app": "core"})
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 			Expect(provisionerPods.Items).To(HaveLen(1))
 
 			By("checking that the bundle file exists")
 			Expect(checkProvisionerBundle(ctx, b, provisionerPods.Items[0].Name)).To(Succeed())
 
 			By("deleting the test Bundle resource")
-			Expect(c.Delete(ctx, b)).To(BeNil())
+			Expect(c.Delete(ctx, b)).To(Succeed())
 
 			By("waiting until the bundle file has been deleted")
 			Eventually(func() error {
@@ -2083,7 +2083,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 					},
 				},
 			}
-			Expect(c.Create(ctx, bd)).To(BeNil())
+			Expect(c.Create(ctx, bd)).To(Succeed())
 
 			By("eventually reporting a successful installation")
 			Eventually(func() (*metav1.Condition, error) {
@@ -2104,7 +2104,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 		})
 		AfterEach(func() {
 			By("deleting the testing BD resource")
-			Expect(c.Delete(ctx, bd)).To(BeNil())
+			Expect(c.Delete(ctx, bd)).To(Succeed())
 		})
 		It("should result in a new Bundle being generated", func() {
 			var (
@@ -2177,7 +2177,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 					},
 				},
 			}
-			Expect(c.Create(ctx, bd)).To(BeNil())
+			Expect(c.Create(ctx, bd)).To(Succeed())
 
 			By("waiting for the BD to eventually report a successful install status")
 			Eventually(func() (*metav1.Condition, error) {
@@ -2199,7 +2199,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 		})
 		It("should eventually result in the installed CRDs being deleted", func() {
 			By("deleting the testing BD resource")
-			Expect(c.Delete(ctx, bd)).To(BeNil())
+			Expect(c.Delete(ctx, bd)).To(Succeed())
 
 			By("waiting until all the installed CRDs have been deleted")
 			selector := util.NewBundleDeploymentLabelSelector(bd)

--- a/test/e2e/registry_provisioner_test.go
+++ b/test/e2e/registry_provisioner_test.go
@@ -49,11 +49,11 @@ var _ = Describe("registry provisioner bundle", func() {
 				},
 			}
 			err := c.Create(ctx, bd)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing BI resource")
-			Expect(c.Delete(ctx, bd)).To(BeNil())
+			Expect(c.Delete(ctx, bd)).To(Succeed())
 		})
 
 		It("should rollout the bundle contents successfully", func() {
@@ -108,11 +108,11 @@ var _ = Describe("registry provisioner bundle", func() {
 				},
 			}
 			err := c.Create(ctx, bd)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		AfterEach(func() {
 			By("deleting the testing BI resource")
-			Expect(c.Delete(ctx, bd)).To(BeNil())
+			Expect(c.Delete(ctx, bd)).To(Succeed())
 		})
 
 		It("should eventually write a failed conversion state to the bundledeployment status", func() {

--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -43,10 +43,10 @@ var _ = Describe("bundle api validating webhook", func() {
 		AfterEach(func() {
 			By("deleting the testing Bundle resource")
 			err := c.Delete(ctx, bundle)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 		It("should create the bundle resource", func() {
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 	When("the bundle source type is git and git properties are not set", func() {


### PR DESCRIPTION
Includes #635 which needs to be merged first

---

Linter which checks for common ginkgo issues like wrong error assertions (`Expect(err).To(BeNil())` instead of `Expect(err).NotTo(HaveOccurred())`), etc.

It also identifies `Expect` calls without a matcher. For example, we have 3 such instances in this repo:

```
test/e2e/rukpakctl_test.go:243:4       ginkgolinter  ginkgo-linter: "Expect": missing assertion method. Expected "Should()", "To()", "ShouldNot()", "ToNot()" or "NotTo()"
internal/storage/storage_test.go:64:3  ginkgolinter  ginkgo-linter: "Expect": missing assertion method. Expected "Should()", "To()", "ShouldNot()", "ToNot()" or "NotTo()"
internal/storage/storage_test.go:69:3  ginkgolinter  ginkgo-linter: "Expect": missing assertion method. Expected "Should()", "To()", "ShouldNot()", "ToNot()" or "NotTo()"
```