### PR TITLE
Adds importas rules

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,12 +30,18 @@ linters-settings:
 
   importas:
     alias:
-    - pkg: k8s.io/api/core/v1
-      alias: corev1
     - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
       alias: metav1
     - pkg: k8s.io/apimachinery/pkg/api/errors
       alias: apierrors
+    - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+      alias: apiextensionsv1
+    - pkg: k8s.io/apimachinery/pkg/util/runtime
+      alias: utilruntime
+    - pkg: "^k8s\\.io/api/([^/]+)/(v[^/]+)$"
+      alias: $1$2
+    - pkg: sigs.k8s.io/controller-runtime
+      alias: ctrl
     - pkg: github.com/operator-framework/rukpak/api/v1alpha1
       alias: rukpakv1alpha1
   goimports:


### PR DESCRIPTION
To enforce common patterns such as importing `k8s.io/api/rbac/v1` as `rbacv1`.