### PR TITLE
Force install namespace for "other" objects

### DIFF
--- a/internal/convert/registryv1.go
+++ b/internal/convert/registryv1.go
@@ -321,6 +321,8 @@ func Convert(in RegistryV1, installNamespace string, targetNamespaces []string) 
 	}
 	for _, obj := range in.Others {
 		obj := obj
+		// Default the namespace of other bundled objects to the installNamespace, like in OLMv0.
+		obj.SetNamespace(installNamespace)
 		objs = append(objs, &obj)
 	}
 	for _, obj := range deployments {


### PR DESCRIPTION
OLMv0 forces all objects in the bundle image to be created in the install namespace even if left blank or filled with a different namespace.

This commit forces all "other" objects to also have their namespace populated via the converter, in the same way one would expect from OLMv0.

This behaviour was tested using the cert-manager operator hub bundle in version v1.12.2, where a Service without explicit namespace is part of the bundle image.