### PR TITLE
E2E Test Labels

### DIFF
--- a/test/e2e/crdvalidator_test.go
+++ b/test/e2e/crdvalidator_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/operator-framework/rukpak/test/testutil"
 )
 
-var _ = Describe("crdvalidator", func() {
+var _ = Describe("crdvalidator", Label("crd-validator"), func() {
 	When("a crd event is emitted", func() {
 		var ctx context.Context
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -19,12 +20,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	"github.com/operator-framework/rukpak/internal/util"
 )
 
 var (
-	cfg        *rest.Config
-	c          client.Client
-	kubeClient kubernetes.Interface
+	cfg             *rest.Config
+	c               client.Client
+	kubeClient      kubernetes.Interface
+	systemNamespace = util.DefaultSystemNamespace
+)
+
+const (
+	defaultUploadServiceName = util.DefaultUploadServiceName
+	testdataDir              = "../../testdata"
 )
 
 func TestE2E(t *testing.T) {
@@ -36,6 +44,10 @@ func TestE2E(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	cfg = ctrl.GetConfigOrDie()
+
+	if val := os.Getenv("RUKPAK_NAMESPACE"); val != "" {
+		systemNamespace = val
+	}
 
 	scheme := runtime.NewScheme()
 	Expect(rukpakv1alpha1.AddToScheme(scheme)).To(Succeed())
@@ -52,4 +64,5 @@ var _ = BeforeSuite(func() {
 
 	kubeClient, err = kubernetes.NewForConfig(cfg)
 	Expect(err).ToNot(HaveOccurred())
+
 })

--- a/test/e2e/helm_provisioner_test.go
+++ b/test/e2e/helm_provisioner_test.go
@@ -84,7 +84,7 @@ var _ = Describe("helm provisioner bundledeployment", func() {
 				deployment := &appsv1.Deployment{}
 
 				Eventually(func() (*appsv1.DeploymentCondition, error) {
-					if err := c.Get(ctx, types.NamespacedName{Name: bd.GetName() + "-hello-world", Namespace: defaultSystemNamespace}, deployment); err != nil {
+					if err := c.Get(ctx, types.NamespacedName{Name: bd.GetName() + "-hello-world", Namespace: systemNamespace}, deployment); err != nil {
 						return nil, err
 					}
 					for _, c := range deployment.Status.Conditions {
@@ -105,7 +105,7 @@ var _ = Describe("helm provisioner bundledeployment", func() {
 				deployment := &appsv1.Deployment{}
 
 				Eventually(func() error {
-					return c.Get(ctx, types.NamespacedName{Name: bd.GetName() + "-hello-world", Namespace: defaultSystemNamespace}, deployment)
+					return c.Get(ctx, types.NamespacedName{Name: bd.GetName() + "-hello-world", Namespace: systemNamespace}, deployment)
 				}).Should(Succeed())
 
 				By("deleting the deployment resource in the helm chart")
@@ -113,7 +113,7 @@ var _ = Describe("helm provisioner bundledeployment", func() {
 
 				By("verifying the deleted deployment resource in the helm chart gets recreated")
 				Eventually(func() (*appsv1.DeploymentCondition, error) {
-					if err := c.Get(ctx, types.NamespacedName{Name: bd.GetName() + "-hello-world", Namespace: defaultSystemNamespace}, deployment); err != nil {
+					if err := c.Get(ctx, types.NamespacedName{Name: bd.GetName() + "-hello-world", Namespace: systemNamespace}, deployment); err != nil {
 						return nil, err
 					}
 					for _, c := range deployment.Status.Conditions {
@@ -370,7 +370,7 @@ var _ = Describe("helm provisioner bundledeployment", func() {
 				deployment := &appsv1.Deployment{}
 
 				Eventually(func() (*appsv1.DeploymentCondition, error) {
-					if err := c.Get(ctx, types.NamespacedName{Name: bd.GetName() + "-hello-world", Namespace: defaultSystemNamespace}, deployment); err != nil {
+					if err := c.Get(ctx, types.NamespacedName{Name: bd.GetName() + "-hello-world", Namespace: systemNamespace}, deployment); err != nil {
 						return nil, err
 					}
 					for _, c := range deployment.Status.Conditions {
@@ -398,7 +398,7 @@ var _ = Describe("helm provisioner bundledeployment", func() {
 				deployment := &appsv1.Deployment{}
 
 				Eventually(func() error {
-					return c.Get(ctx, types.NamespacedName{Name: bd.GetName() + "-hello-world", Namespace: defaultSystemNamespace}, deployment)
+					return c.Get(ctx, types.NamespacedName{Name: bd.GetName() + "-hello-world", Namespace: systemNamespace}, deployment)
 				}).Should(Succeed())
 
 				By("deleting the deployment resource in the helm chart")
@@ -406,7 +406,7 @@ var _ = Describe("helm provisioner bundledeployment", func() {
 
 				By("verifying the deleted deployment resource in the helm chart gets recreated")
 				Eventually(func() (*appsv1.DeploymentCondition, error) {
-					if err := c.Get(ctx, types.NamespacedName{Name: bd.GetName() + "-hello-world", Namespace: defaultSystemNamespace}, deployment); err != nil {
+					if err := c.Get(ctx, types.NamespacedName{Name: bd.GetName() + "-hello-world", Namespace: systemNamespace}, deployment); err != nil {
 						return nil, err
 					}
 					for _, c := range deployment.Status.Conditions {
@@ -551,7 +551,7 @@ var _ = Describe("helm provisioner bundledeployment", func() {
 			deployment := &appsv1.Deployment{}
 
 			Eventually(func() (*appsv1.DeploymentCondition, error) {
-				if err := c.Get(ctx, types.NamespacedName{Name: bd.GetName() + "-fromvalues", Namespace: defaultSystemNamespace}, deployment); err != nil {
+				if err := c.Get(ctx, types.NamespacedName{Name: bd.GetName() + "-fromvalues", Namespace: systemNamespace}, deployment); err != nil {
 					return nil, err
 				}
 				for _, c := range deployment.Status.Conditions {

--- a/test/e2e/registry_provisioner_test.go
+++ b/test/e2e/registry_provisioner_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var _ = Describe("registry provisioner bundle", func() {
-	When("a BundleDeployment targets a registry+v1 Bundle", func() {
+	When("a BundleDeployment targets a registry+v1 Bundle", Label("registry-src"), func() {
 		var (
 			bd  *rukpakv1alpha1.BundleDeployment
 			ctx context.Context
@@ -75,7 +75,7 @@ var _ = Describe("registry provisioner bundle", func() {
 			))
 		})
 	})
-	When("a BundleDeployment targets an invalid registry+v1 Bundle", func() {
+	When("a BundleDeployment targets an invalid registry+v1 Bundle", Label("registry-src"), func() {
 		var (
 			bd  *rukpakv1alpha1.BundleDeployment
 			ctx context.Context


### PR DESCRIPTION
Adds labels to tests which require an image registry, git repo, etc. to be setup in order for the test to run. Also adds an override for the namespace.

As an example, with these changes you can run the e2e test suite without the crd-validator suite and without tests requiring an image registry or git repo by using these flags:
```E2E_FLAGS='--label-filter="!crd-validator && !registry-src && !local-git-src"' make test-e2e```

TODO either for this PR or a future PR is to add a complete set of labels to the test suite. I've prioritized these ones specifically since they allow us to run a good set of e2e tests without any dependence on setting up an image registry or private/local git repo.