### PR TITLE
Makes codecov-action optional

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -20,5 +20,4 @@ jobs:
       - uses: codecov/codecov-action@v3
         with:
           files: cover.out
-          fail_ci_if_error: true
           functionalities: fixes


### PR DESCRIPTION
We do not want to fail the job if codecov fails
to upload the report due to rate limiting.