### PR TITLE
GHA: only run go-apidiff for PRs

### DIFF
--- a/.github/workflows/go-apidiff.yaml
+++ b/.github/workflows/go-apidiff.yaml
@@ -1,16 +1,10 @@
 name: go-apidiff
 
 on:
-  workflow_dispatch:
   pull_request:
-  merge_group:
-  push:
-    branches:
-    - main
 
 jobs:
   go-apidiff:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - name: Check out code into the Go module directory


### PR DESCRIPTION
go-apidiff is informational and can only be used effectively in the context of a comparison between two different commits. There is also no need to run it in the merge queue because it will not block merging any (as it is not required to pass in branch protection settings)

Removing non-PR triggers for go-apidiff.