### PR TITLE
Reintroduce webhook version flag

### DIFF
--- a/cmd/webhooks/main.go
+++ b/cmd/webhooks/main.go
@@ -57,6 +57,7 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.StringVar(&systemNamespace, "system-namespace", "", "Configures the namespace that gets used to deploy system resources.")
+	flag.BoolVar(&rukpakVersion, "version", false, "Displays rukpak version information")
 	flag.BoolVar(&enableHTTP2, "enable-http2", enableHTTP2, "If HTTP/2 should be enabled for the webhook servers.")
 
 	opts := zap.Options{


### PR DESCRIPTION
Reintroduces the version flag to the webhook binary which was accidentally removed in Pull Request #754.