### PR TITLE
WIP: Create new generic bundle provisioner

### DIFF
--- a/cmd/rukpakctl/cmd/run.go
+++ b/cmd/rukpakctl/cmd/run.go
@@ -12,6 +12,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
+	"github.com/operator-framework/rukpak/internal/provisioner/generic"
 	"github.com/operator-framework/rukpak/internal/provisioner/plain"
 	"github.com/operator-framework/rukpak/internal/rukpakctl"
 	"github.com/operator-framework/rukpak/internal/util"
@@ -85,6 +86,6 @@ one version to the next.
 	cmd.Flags().StringVar(&uploadServiceName, "upload-service-name", util.DefaultUploadServiceName, "the name of the service of the upload manager.")
 	cmd.Flags().StringVar(&caSecretName, "ca-secret-name", "rukpak-ca", "the name of the secret in the system namespace containing the root CAs used to authenticate the upload service.")
 	cmd.Flags().StringVar(&bundleDeploymentProvisionerClassName, "bundle-deployment-provisioner-class", plain.ProvisionerID, "Provisioner class name to set on bundle deployment.")
-	cmd.Flags().StringVar(&bundleProvisionerClassName, "bundle-provisioner-class", plain.ProvisionerID, "Provisioner class name to set on bundle.")
+	cmd.Flags().StringVar(&bundleProvisionerClassName, "bundle-provisioner-class", generic.ProvisionerID, "Provisioner class name to set on bundle.")
 	return cmd
 }

--- a/internal/provisioner/generic/generic.go
+++ b/internal/provisioner/generic/generic.go
@@ -1,0 +1,17 @@
+package generic
+
+import (
+	"context"
+	"io/fs"
+
+	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+)
+
+const (
+	// ProvisionerID is the unique generic provisioner ID
+	ProvisionerID = "core-rukpak-io-generic"
+)
+
+func HandleBundle(_ context.Context, fsys fs.FS, _ *rukpakv1alpha1.Bundle) (fs.FS, error) {
+	return fsys, nil
+}

--- a/internal/provisioner/plain/plain.go
+++ b/internal/provisioner/plain/plain.go
@@ -24,15 +24,12 @@ const (
 	manifestsDir = "manifests"
 )
 
-func HandleBundle(_ context.Context, fsys fs.FS, _ *rukpakv1alpha1.Bundle) (fs.FS, error) {
-	if err := ValidateBundle(fsys); err != nil {
-		return nil, err
-	}
-	return fsys, nil
-}
-
 func HandleBundleDeployment(_ context.Context, fsys fs.FS, bd *rukpakv1alpha1.BundleDeployment) (*chart.Chart, chartutil.Values, error) {
-	chrt, err := chartFromBundle(fsys, bd)
+	if err := ValidateBundle(fsys); err != nil {
+		return nil, nil, err
+	}
+
+	chrt, err := ChartFromBundle(fsys, bd)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -81,7 +78,7 @@ func getObjects(bundle fs.FS, manifest fs.DirEntry) ([]client.Object, error) {
 	return util.ManifestObjects(manifestReader, manifestPath)
 }
 
-func chartFromBundle(fsys fs.FS, bd *rukpakv1alpha1.BundleDeployment) (*chart.Chart, error) {
+func ChartFromBundle(fsys fs.FS, bd *rukpakv1alpha1.BundleDeployment) (*chart.Chart, error) {
 	objects, err := getBundleObjects(fsys)
 	if err != nil {
 		return nil, fmt.Errorf("read bundle objects from bundle: %v", err)

--- a/internal/provisioner/registry/registry.go
+++ b/internal/provisioner/registry/registry.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"io/fs"
 
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chartutil"
+
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
 	"github.com/operator-framework/rukpak/internal/convert"
 	"github.com/operator-framework/rukpak/internal/provisioner/plain"
@@ -15,14 +18,19 @@ const (
 	ProvisionerID = "core-rukpak-io-registry"
 )
 
-func HandleBundle(_ context.Context, fsys fs.FS, _ *rukpakv1alpha1.Bundle) (fs.FS, error) {
+func HandleBundleDeployment(_ context.Context, fsys fs.FS, bd *rukpakv1alpha1.BundleDeployment) (*chart.Chart, chartutil.Values, error) {
 	plainFS, err := convert.RegistryV1ToPlain(fsys)
 	if err != nil {
-		return nil, fmt.Errorf("convert registry+v1 bundle to plain+v0 bundle: %v", err)
+		return nil, nil, fmt.Errorf("convert registry+v1 bundle to plain+v0 bundle: %v", err)
 	}
 
 	if err := plain.ValidateBundle(plainFS); err != nil {
-		return nil, fmt.Errorf("validate bundle: %v", err)
+		return nil, nil, fmt.Errorf("validate bundle: %v", err)
 	}
-	return plainFS, nil
+
+	chrt, err := plain.ChartFromBundle(plainFS, bd)
+	if err != nil {
+		return nil, nil, err
+	}
+	return chrt, nil, nil
 }

--- a/test/e2e/plain_provisioner_test.go
+++ b/test/e2e/plain_provisioner_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
+	"github.com/operator-framework/rukpak/internal/provisioner/generic"
 	"github.com/operator-framework/rukpak/internal/provisioner/plain"
 	"github.com/operator-framework/rukpak/internal/rukpakctl"
 	"github.com/operator-framework/rukpak/internal/storage"
@@ -104,7 +105,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					GenerateName: "olm-crds-valid",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plain.ProvisionerID,
+					ProvisionerClassName: generic.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -222,7 +223,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					GenerateName: "olm-crds-valid",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plain.ProvisionerID,
+					ProvisionerClassName: generic.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -283,7 +284,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					GenerateName: "olm-crds-invalid",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plain.ProvisionerID,
+					ProvisionerClassName: generic.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -343,7 +344,7 @@ var _ = Describe("plain provisioner bundle", func() {
 		})
 	})
 
-	When("a bundle containing no manifests is created", func() {
+	PWhen("a bundle containing no manifests is created", func() {
 		var (
 			bundle *rukpakv1alpha1.Bundle
 			ctx    context.Context
@@ -357,7 +358,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					GenerateName: "olm-crds-unsupported",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plain.ProvisionerID,
+					ProvisionerClassName: generic.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -392,7 +393,7 @@ var _ = Describe("plain provisioner bundle", func() {
 		})
 	})
 
-	When("a bundle containing an empty manifests directory is created", func() {
+	PWhen("a bundle containing an empty manifests directory is created", func() {
 		var (
 			bundle *rukpakv1alpha1.Bundle
 			ctx    context.Context
@@ -406,7 +407,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					GenerateName: "olm-crds-unsupported",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plain.ProvisionerID,
+					ProvisionerClassName: generic.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -460,7 +461,7 @@ var _ = Describe("plain provisioner bundle", func() {
 						GenerateName: "combo-git-commit",
 					},
 					Spec: rukpakv1alpha1.BundleSpec{
-						ProvisionerClassName: plain.ProvisionerID,
+						ProvisionerClassName: generic.ProvisionerID,
 						Source: rukpakv1alpha1.BundleSource{
 							Type: rukpakv1alpha1.SourceTypeGit,
 							Git: &rukpakv1alpha1.GitSource{
@@ -512,7 +513,7 @@ var _ = Describe("plain provisioner bundle", func() {
 						GenerateName: "combo-git-tag",
 					},
 					Spec: rukpakv1alpha1.BundleSpec{
-						ProvisionerClassName: plain.ProvisionerID,
+						ProvisionerClassName: generic.ProvisionerID,
 						Source: rukpakv1alpha1.BundleSource{
 							Type: rukpakv1alpha1.SourceTypeGit,
 							Git: &rukpakv1alpha1.GitSource{
@@ -583,7 +584,7 @@ var _ = Describe("plain provisioner bundle", func() {
 						GenerateName: "combo-git-branch",
 					},
 					Spec: rukpakv1alpha1.BundleSpec{
-						ProvisionerClassName: plain.ProvisionerID,
+						ProvisionerClassName: generic.ProvisionerID,
 						Source: rukpakv1alpha1.BundleSource{
 							Type: rukpakv1alpha1.SourceTypeGit,
 							Git: &rukpakv1alpha1.GitSource{
@@ -654,7 +655,7 @@ var _ = Describe("plain provisioner bundle", func() {
 						GenerateName: "combo-git-custom-dir",
 					},
 					Spec: rukpakv1alpha1.BundleSpec{
-						ProvisionerClassName: plain.ProvisionerID,
+						ProvisionerClassName: generic.ProvisionerID,
 						Source: rukpakv1alpha1.BundleSource{
 							Type: rukpakv1alpha1.SourceTypeGit,
 							Git: &rukpakv1alpha1.GitSource{
@@ -728,7 +729,7 @@ var _ = Describe("plain provisioner bundle", func() {
 						GenerateName: "combo-git-branch",
 					},
 					Spec: rukpakv1alpha1.BundleSpec{
-						ProvisionerClassName: plain.ProvisionerID,
+						ProvisionerClassName: generic.ProvisionerID,
 						Source: rukpakv1alpha1.BundleSource{
 							Type: rukpakv1alpha1.SourceTypeGit,
 							Git: &rukpakv1alpha1.GitSource{
@@ -790,7 +791,7 @@ var _ = Describe("plain provisioner bundle", func() {
 						GenerateName: "combo-git-branch",
 					},
 					Spec: rukpakv1alpha1.BundleSpec{
-						ProvisionerClassName: plain.ProvisionerID,
+						ProvisionerClassName: generic.ProvisionerID,
 						Source: rukpakv1alpha1.BundleSource{
 							Type: rukpakv1alpha1.SourceTypeGit,
 							Git: &rukpakv1alpha1.GitSource{
@@ -885,7 +886,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					GenerateName: "combo-local-",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plain.ProvisionerID,
+					ProvisionerClassName: generic.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeConfigMaps,
 						ConfigMaps: []rukpakv1alpha1.ConfigMapSource{{
@@ -936,7 +937,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					GenerateName: "combo-local-",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plain.ProvisionerID,
+					ProvisionerClassName: generic.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeConfigMaps,
 						ConfigMaps: []rukpakv1alpha1.ConfigMapSource{{
@@ -972,7 +973,7 @@ var _ = Describe("plain provisioner bundle", func() {
 		})
 	})
 
-	When("the bundle is backed by an invalid configmap", func() {
+	PWhen("the bundle is backed by an invalid configmap", func() {
 		var (
 			bundle    *rukpakv1alpha1.Bundle
 			configmap *corev1.ConfigMap
@@ -1012,7 +1013,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					GenerateName: "combo-local-",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plain.ProvisionerID,
+					ProvisionerClassName: generic.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeConfigMaps,
 						ConfigMaps: []rukpakv1alpha1.ConfigMapSource{{
@@ -1064,7 +1065,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					Name: fmt.Sprintf("valid-upload-%s", rand.String(8)),
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plain.ProvisionerID,
+					ProvisionerClassName: generic.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type:   rukpakv1alpha1.SourceTypeUpload,
 						Upload: &rukpakv1alpha1.UploadSource{},
@@ -1104,7 +1105,7 @@ var _ = Describe("plain provisioner bundle", func() {
 		})
 	})
 
-	When("the bundle is backed by an invalid upload", func() {
+	PWhen("the bundle is backed by an invalid upload", func() {
 		var (
 			bundle *rukpakv1alpha1.Bundle
 			ctx    context.Context
@@ -1122,7 +1123,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					Name: fmt.Sprintf("invalid-upload-%s", rand.String(8)),
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plain.ProvisionerID,
+					ProvisionerClassName: generic.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type:   rukpakv1alpha1.SourceTypeUpload,
 						Upload: &rukpakv1alpha1.UploadSource{},
@@ -1168,7 +1169,7 @@ var _ = Describe("plain provisioner bundle", func() {
 		})
 	})
 
-	When("a bundle containing nested directory is created", func() {
+	PWhen("a bundle containing nested directory is created", func() {
 		var (
 			bundle *rukpakv1alpha1.Bundle
 			ctx    context.Context
@@ -1186,7 +1187,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					GenerateName: "namespace-subdirs",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plain.ProvisionerID,
+					ProvisionerClassName: generic.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -1234,7 +1235,7 @@ var _ = Describe("plain provisioner bundle", func() {
 					GenerateName: "combo-git-commit",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plain.ProvisionerID,
+					ProvisionerClassName: generic.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeGit,
 						Git: &rukpakv1alpha1.GitSource{
@@ -1396,7 +1397,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 					ProvisionerClassName: plain.ProvisionerID,
 					Template: rukpakv1alpha1.BundleTemplate{
 						Spec: rukpakv1alpha1.BundleSpec{
-							ProvisionerClassName: plain.ProvisionerID,
+							ProvisionerClassName: generic.ProvisionerID,
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
@@ -1493,7 +1494,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 						return err
 					}
 					bd.Spec.Template.Spec = rukpakv1alpha1.BundleSpec{
-						ProvisionerClassName: plain.ProvisionerID,
+						ProvisionerClassName: generic.ProvisionerID,
 						Source: rukpakv1alpha1.BundleSource{
 							Type: rukpakv1alpha1.SourceTypeGit,
 							Git: &rukpakv1alpha1.GitSource{
@@ -1651,7 +1652,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 							},
 						},
 						Spec: rukpakv1alpha1.BundleSpec{
-							ProvisionerClassName: plain.ProvisionerID,
+							ProvisionerClassName: generic.ProvisionerID,
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
@@ -1710,7 +1711,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 							},
 						},
 						Spec: rukpakv1alpha1.BundleSpec{
-							ProvisionerClassName: plain.ProvisionerID,
+							ProvisionerClassName: generic.ProvisionerID,
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
@@ -1789,7 +1790,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 							},
 						},
 						Spec: rukpakv1alpha1.BundleSpec{
-							ProvisionerClassName: plain.ProvisionerID,
+							ProvisionerClassName: generic.ProvisionerID,
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
@@ -1823,9 +1824,8 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 				Not(BeNil()),
 				WithTransform(func(c *metav1.Condition) string { return c.Type }, Equal(rukpakv1alpha1.TypeHasValidBundle)),
 				WithTransform(func(c *metav1.Condition) metav1.ConditionStatus { return c.Status }, Equal(metav1.ConditionFalse)),
-				WithTransform(func(c *metav1.Condition) string { return c.Reason }, Equal(rukpakv1alpha1.ReasonUnpackFailed)),
+				WithTransform(func(c *metav1.Condition) string { return c.Reason }, Equal(rukpakv1alpha1.ReasonBundleLoadFailed)),
 				WithTransform(func(c *metav1.Condition) string { return c.Message }, And(
-					ContainSubstring(`Failed to unpack the olm-apis`),
 					ContainSubstring(`get objects from bundle manifests: subdirectories are not allowed within the "manifests" directory of the bundle image filesystem: found "manifests/emptydir"`),
 				)),
 			))
@@ -1853,7 +1853,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 							},
 						},
 						Spec: rukpakv1alpha1.BundleSpec{
-							ProvisionerClassName: plain.ProvisionerID,
+							ProvisionerClassName: generic.ProvisionerID,
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
@@ -1910,7 +1910,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 								},
 							},
 							Spec: rukpakv1alpha1.BundleSpec{
-								ProvisionerClassName: plain.ProvisionerID,
+								ProvisionerClassName: generic.ProvisionerID,
 								Source: rukpakv1alpha1.BundleSource{
 									Type: rukpakv1alpha1.SourceTypeImage,
 									Image: &rukpakv1alpha1.ImageSource{
@@ -1971,7 +1971,7 @@ var _ = Describe("plain provisioner bundledeployment", func() {
 							},
 						},
 						Spec: rukpakv1alpha1.BundleSpec{
-							ProvisionerClassName: plain.ProvisionerID,
+							ProvisionerClassName: generic.ProvisionerID,
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
@@ -2021,7 +2021,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 					GenerateName: "e2e-ownerref-bundle-valid",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plain.ProvisionerID,
+					ProvisionerClassName: generic.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeImage,
 						Image: &rukpakv1alpha1.ImageSource{
@@ -2103,7 +2103,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 							Labels: labels,
 						},
 						Spec: rukpakv1alpha1.BundleSpec{
-							ProvisionerClassName: plain.ProvisionerID,
+							ProvisionerClassName: generic.ProvisionerID,
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
@@ -2197,7 +2197,7 @@ var _ = Describe("plain provisioner garbage collection", func() {
 							},
 						},
 						Spec: rukpakv1alpha1.BundleSpec{
-							ProvisionerClassName: plain.ProvisionerID,
+							ProvisionerClassName: generic.ProvisionerID,
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{

--- a/test/e2e/registry_provisioner_test.go
+++ b/test/e2e/registry_provisioner_test.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
-	"github.com/operator-framework/rukpak/internal/provisioner/plain"
+	"github.com/operator-framework/rukpak/internal/provisioner/generic"
 	"github.com/operator-framework/rukpak/internal/provisioner/registry"
 )
 
@@ -29,7 +29,7 @@ var _ = Describe("registry provisioner bundle", func() {
 					GenerateName: "prometheus",
 				},
 				Spec: rukpakv1alpha1.BundleDeploymentSpec{
-					ProvisionerClassName: plain.ProvisionerID,
+					ProvisionerClassName: registry.ProvisionerID,
 					Template: rukpakv1alpha1.BundleTemplate{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -37,7 +37,7 @@ var _ = Describe("registry provisioner bundle", func() {
 							},
 						},
 						Spec: rukpakv1alpha1.BundleSpec{
-							ProvisionerClassName: registry.ProvisionerID,
+							ProvisionerClassName: generic.ProvisionerID,
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
@@ -88,7 +88,7 @@ var _ = Describe("registry provisioner bundle", func() {
 					GenerateName: "cincinnati",
 				},
 				Spec: rukpakv1alpha1.BundleDeploymentSpec{
-					ProvisionerClassName: plain.ProvisionerID,
+					ProvisionerClassName: registry.ProvisionerID,
 					Template: rukpakv1alpha1.BundleTemplate{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{
@@ -96,7 +96,7 @@ var _ = Describe("registry provisioner bundle", func() {
 							},
 						},
 						Spec: rukpakv1alpha1.BundleSpec{
-							ProvisionerClassName: registry.ProvisionerID,
+							ProvisionerClassName: generic.ProvisionerID,
 							Source: rukpakv1alpha1.BundleSource{
 								Type: rukpakv1alpha1.SourceTypeImage,
 								Image: &rukpakv1alpha1.ImageSource{
@@ -125,7 +125,7 @@ var _ = Describe("registry provisioner bundle", func() {
 				Not(BeNil()),
 				WithTransform(func(c *metav1.Condition) string { return c.Type }, Equal(rukpakv1alpha1.TypeHasValidBundle)),
 				WithTransform(func(c *metav1.Condition) metav1.ConditionStatus { return c.Status }, Equal(metav1.ConditionFalse)),
-				WithTransform(func(c *metav1.Condition) string { return c.Reason }, Equal(rukpakv1alpha1.ReasonUnpackFailed)),
+				WithTransform(func(c *metav1.Condition) string { return c.Reason }, Equal(rukpakv1alpha1.ReasonBundleLoadFailed)),
 				WithTransform(func(c *metav1.Condition) string { return c.Message }, ContainSubstring("convert registry+v1 bundle to plain+v0 bundle: AllNamespace install mode must be enabled")),
 			))
 		})

--- a/test/e2e/rukpakctl_test.go
+++ b/test/e2e/rukpakctl_test.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	rukpakv1alpha1 "github.com/operator-framework/rukpak/api/v1alpha1"
-	"github.com/operator-framework/rukpak/internal/provisioner/plain"
+	"github.com/operator-framework/rukpak/internal/provisioner/generic"
 )
 
 const (
@@ -111,7 +111,7 @@ var _ = Describe("rukpakctl run subcommand", func() {
 			Expect(strings.Contains(message, "no such file or directory")).To(BeTrue())
 		})
 	})
-	When("run executed with a bundle cannot unpacked", func() {
+	PWhen("run executed with a bundle cannot unpacked", func() {
 		var (
 			ctx                  context.Context
 			bundlename           string
@@ -189,7 +189,7 @@ var _ = Describe("rukpakctl content subcommand", func() {
 					GenerateName: "combo-git-commit",
 				},
 				Spec: rukpakv1alpha1.BundleSpec{
-					ProvisionerClassName: plain.ProvisionerID,
+					ProvisionerClassName: generic.ProvisionerID,
 					Source: rukpakv1alpha1.BundleSource{
 						Type: rukpakv1alpha1.SourceTypeGit,
 						Git: &rukpakv1alpha1.GitSource{
@@ -260,7 +260,7 @@ var _ = Describe("rukpakctl content subcommand", func() {
 			)))
 		})
 	})
-	When("content executed on a failed bundle", func() {
+	PWhen("content executed on a failed bundle", func() {
 		var (
 			ctx                  context.Context
 			bundlename           string


### PR DESCRIPTION
Also, remove plain and registry bundle provisioners and move their logic into the respective bundle deployment provisioners.

We have a whole slew of e2e tests that exercise a bunch of "invalid" bundle unpacking failures that I (for now) marked as pending. That logic needs to be either moved to be tested at the bundle deployment level, where it the format-specific logic now lives, or perhaps it can be dropped or moved to unit/integration tests.

This is the idea that I mentioned in #772. 