### PR TITLE
:sparkles: Cleanups after removing BundleAPI

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -42,8 +42,8 @@ linters-settings:
       alias: $1$2
     - pkg: sigs.k8s.io/controller-runtime
       alias: ctrl
-    - pkg: github.com/operator-framework/rukpak/api/v1alpha1
-      alias: rukpakv1alpha1
+    - pkg: github.com/operator-framework/rukpak/api/v1alpha2
+      alias: rukpakv1alpha2
   goimports:
     local-prefixes: github.com/operator-framework/rukpak
 

--- a/api/v1alpha2/bundledeployment_types.go
+++ b/api/v1alpha2/bundledeployment_types.go
@@ -27,9 +27,8 @@ var (
 )
 
 const (
-	TypeHasValidBundle = "HasValidBundle"
-	TypeHealthy        = "Healthy"
-	TypeInstalled      = "Installed"
+	TypeHealthy   = "Healthy"
+	TypeInstalled = "Installed"
 
 	ReasonBundleLoadFailed          = "BundleLoadFailed"
 	ReasonCreateDynamicWatchFailed  = "CreateDynamicWatchFailed"

--- a/internal/controllers/bundledeployment/bundledeployment.go
+++ b/internal/controllers/bundledeployment/bundledeployment.go
@@ -287,7 +287,7 @@ func (c *controller) reconcile(ctx context.Context, bd *rukpakv1alpha2.BundleDep
 	bundleFS, err := c.storage.Load(ctx, bd)
 	if err != nil {
 		meta.SetStatusCondition(&bd.Status.Conditions, metav1.Condition{
-			Type:    rukpakv1alpha2.TypeHasValidBundle,
+			Type:    rukpakv1alpha2.TypeInstalled,
 			Status:  metav1.ConditionFalse,
 			Reason:  rukpakv1alpha2.ReasonBundleLoadFailed,
 			Message: err.Error(),


### PR DESCRIPTION
This PR makes the follwing changes:
1. Fixes the reference to v1alpha1 APIs in the linter.
2. TypeHasValidBundle was being set to false only when the bundle load errored. Switching the condition to be TypeInstalled instead.
3. Fix documentation on provisioners.

Follow up #774 