### PR TITLE
Improve error message for all namespaces

### DIFF
--- a/pkg/convert/registryv1.go
+++ b/pkg/convert/registryv1.go
@@ -148,6 +148,7 @@ func validateTargetNamespaces(supportedInstallModes sets.Set[string], installNam
 		if supportedInstallModes.Has(string(v1alpha1.InstallModeTypeAllNamespaces)) {
 			return nil
 		}
+		return fmt.Errorf("supported install modes %v do not support targeting all namespaces", sets.List(supportedInstallModes))
 	case set.Len() == 1 && !set.Has(""):
 		if supportedInstallModes.Has(string(v1alpha1.InstallModeTypeSingleNamespace)) {
 			return nil


### PR DESCRIPTION
Will result in this message:

> supported install modes [MultiNamespace OwnNamespace SingleNamespace] do not support target all namespaces

Instead of this when targeting all namespaces:

> supported install modes [OwnNamespace SingleNamespace MultiNamespace] do not support target namespaces []