### PR TITLE
Update certificate support

### DIFF
--- a/api/v1alpha2/bundle_types.go
+++ b/api/v1alpha2/bundle_types.go
@@ -67,6 +67,8 @@ type ImageSource struct {
 	// This should not be used in a production environment.
 	// +optional
 	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
+	// CertificateData contains the PEM data of the certificate that is to be used for the TLS connection
+	CertificateData string `json:"certificateData,omitempty"`
 }
 
 type GitSource struct {

--- a/cmd/core/main.go
+++ b/cmd/core/main.go
@@ -199,7 +199,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	unpacker, err := source.NewDefaultUnpacker(mgr, systemNamespace, unpackCacheDir, rootCAs)
+	unpacker, err := source.NewDefaultUnpacker(mgr, systemNamespace, unpackCacheDir)
 	if err != nil {
 		setupLog.Error(err, "unable to setup bundle unpacker")
 		os.Exit(1)

--- a/cmd/helm/main.go
+++ b/cmd/helm/main.go
@@ -189,7 +189,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	unpacker, err := source.NewDefaultUnpacker(mgr, systemNamespace, unpackCacheDir, rootCAs)
+	unpacker, err := source.NewDefaultUnpacker(mgr, systemNamespace, unpackCacheDir)
 	if err != nil {
 		setupLog.Error(err, "unable to setup bundle unpacker")
 		os.Exit(1)

--- a/manifests/base/apis/crds/core.rukpak.io_bundledeployments.yaml
+++ b/manifests/base/apis/crds/core.rukpak.io_bundledeployments.yaml
@@ -223,6 +223,10 @@ spec:
                     description: Image is the bundle image that backs the content
                       of this bundle.
                     properties:
+                      certificateData:
+                        description: CertificateData contains the PEM data of the
+                          certificate that is to be used for the TLS connection
+                        type: string
                       insecureSkipTLSVerify:
                         description: |-
                           InsecureSkipTLSVerify indicates that TLS certificate validation should be skipped.
@@ -468,6 +472,10 @@ spec:
                     description: Image is the bundle image that backs the content
                       of this bundle.
                     properties:
+                      certificateData:
+                        description: CertificateData contains the PEM data of the
+                          certificate that is to be used for the TLS connection
+                        type: string
                       insecureSkipTLSVerify:
                         description: |-
                           InsecureSkipTLSVerify indicates that TLS certificate validation should be skipped.

--- a/pkg/source/unpacker.go
+++ b/pkg/source/unpacker.go
@@ -2,11 +2,8 @@ package source
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"io/fs"
-	"net/http"
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -103,14 +100,7 @@ func (s *unpacker) Cleanup(ctx context.Context, bundle *rukpakv1alpha2.BundleDep
 // source types.
 //
 // TODO: refactor NewDefaultUnpacker due to growing parameter list
-func NewDefaultUnpacker(mgr manager.Manager, namespace, cacheDir string, rootCAs *x509.CertPool) (Unpacker, error) {
-	httpTransport := http.DefaultTransport.(*http.Transport).Clone()
-	if httpTransport.TLSClientConfig == nil {
-		httpTransport.TLSClientConfig = &tls.Config{
-			MinVersion: tls.VersionTLS12,
-		}
-	}
-	httpTransport.TLSClientConfig.RootCAs = rootCAs
+func NewDefaultUnpacker(mgr manager.Manager, namespace, cacheDir string) (Unpacker, error) {
 	return NewUnpacker(map[rukpakv1alpha2.SourceType]Unpacker{
 		rukpakv1alpha2.SourceTypeImage: &ImageRegistry{
 			BaseCachePath: cacheDir,

--- a/test/tools/imageregistry/image-registry-secure.sh
+++ b/test/tools/imageregistry/image-registry-secure.sh
@@ -47,6 +47,7 @@ spec:
   isCA: true
   dnsNames:
     - ${name}-secure.${namespace}.svc
+    - ${name}-secure.${namespace}.svc.cluster.local
   privateKey:
     algorithm: ECDSA
     size: 256

--- a/test/tools/imageregistry/image-registry.sh
+++ b/test/tools/imageregistry/image-registry.sh
@@ -47,6 +47,7 @@ spec:
   isCA: true
   dnsNames:
     - ${name}.${namespace}.svc
+    - ${name}.${namespace}.svc.cluster.local
   privateKey:
     algorithm: ECDSA
     size: 256


### PR DESCRIPTION
Remove `rootCAs` from the `NewDefaultUnpacker` API, the argument is no longer used for HTTP transport.

Add `CertificateData` to the ImageSource struct. This is PEM-encoded data (straight from a Secret[tls.crt]) to be used to validate the certificate used to access an image regidstry (works along side the `InsecureSkipTLSVerify` option).